### PR TITLE
Move urls to extra urls.py

### DIFF
--- a/cosinnus_oauth_client/extra_urls.py
+++ b/cosinnus_oauth_client/extra_urls.py
@@ -1,0 +1,11 @@
+from django.conf.urls import url
+
+from cosinnus_oauth_client.views import custom_connections
+from cosinnus_oauth_client.views import custom_password_set
+from cosinnus_oauth_client.views import welcome_oauth
+
+urlpatterns = [
+    url(r'social/connections/$', custom_connections, name='socialaccount_connections'),
+    url(r'password/set/', custom_password_set, name='account_set_password'),
+    url(r'welcome/', welcome_oauth, name='welcome_oauth'),
+]


### PR DESCRIPTION
I had to put the urls to extra_urls.py to prevent circular imports (because of how allauth works). Update urls on the client platform like this:

```
if getattr(settings, 'COSINNUS_IS_OAUTH_CLIENT', False) and getattr(settings, 'COSINNUS_OAUTH_SERVER_BASEURL', False):
    urlpatterns += [
        url(r'accounts/', include('cosinnus_oauth_client.extra_urls')),
        url(r'accounts/', include('allauth.urls'))
    ]
```