### PR TITLE
Write language to response cookie as writing to session is depricated

### DIFF
--- a/cosinnus/views/common.py
+++ b/cosinnus/views/common.py
@@ -87,25 +87,31 @@ generic_error_page_view = GenericErrorPageView.as_view()
 
 
 class SwitchLanguageView(RedirectView):
-    
+
     permanent = False
-    
+
     def get(self, request, *args, **kwargs):
         language = kwargs.pop('language', None)
-        
+
         if not language or language not in list(dict(settings.LANGUAGES).keys()):
             messages.error(request, _('The language "%s" is not supported' % language))
         else:
-            request.session[LANGUAGE_SESSION_KEY] = language
-            request.session['django_language'] = language
-            request.LANGUAGE_CODE = language
-        #messages.success(request, _('Language was switched successfully.'))
-        
-        return super(SwitchLanguageView, self).get(request, *args, **kwargs)
-        
+            response = super(SwitchLanguageView, self).get(request, *args, **kwargs)
+            response.set_cookie(
+                settings.LANGUAGE_COOKIE_NAME,
+                language,
+                max_age=settings.LANGUAGE_COOKIE_AGE,
+                path=settings.LANGUAGE_COOKIE_PATH,
+                domain=settings.LANGUAGE_COOKIE_DOMAIN,
+                secure=settings.LANGUAGE_COOKIE_SECURE,
+                httponly=settings.LANGUAGE_COOKIE_HTTPONLY,
+                samesite=settings.LANGUAGE_COOKIE_SAMESITE,
+            )
+        return response
+
     def get_redirect_url(self, **kwargs):
         return safe_redirect(self.request.GET.get('next', self.request.META.get('HTTP_REFERER', '/')), self.request)
-        
+
 
 switch_language = SwitchLanguageView.as_view()
 


### PR DESCRIPTION
Problem: https://docs.djangoproject.com/en/4.0/releases/3.0/#miscellaneous:

Because accessing the language in the session rather than in the cookie is deprecated, LocaleMiddleware no longer looks for the user’s language in the session

Code from here: https://github.com/django/django/blob/main/django/views/i18n.py#L54


