### PR TITLE
Log out a user from rocket chat when logging out

### DIFF
--- a/cosinnus/default_settings.py
+++ b/cosinnus/default_settings.py
@@ -466,7 +466,8 @@ def define_cosinnus_base_settings(project_settings, project_base_path):
     COSINNUS_CHAT_BASE_URL = f"https://chat.{project_settings['COSINNUS_PORTAL_URL']}"
     COSINNUS_CHAT_USER = env("WECHANGE_COSINNUS_CHAT_USER", default=f"{project_settings['COSINNUS_PORTAL_NAME']}-bot")
     COSINNUS_CHAT_PASSWORD = env("WECHANGE_COSINNUS_CHAT_PASSWORD", default='')
-    
+    COSINNUS_CHAT_SESSION_COOKIE_DOMAIN = project_settings['COSINNUS_PORTAL_URL']
+
     # Nextcloud
     COSINNUS_CLOUD_ENABLED = False
     COSINNUS_CLOUD_NEXTCLOUD_URL = f"https://cloud.{project_settings['COSINNUS_PORTAL_URL']}"

--- a/cosinnus/views/common.py
+++ b/cosinnus/views/common.py
@@ -21,6 +21,7 @@ from django.views.generic.base import View, TemplateView
 import requests
 
 from cosinnus.conf import settings
+from cosinnus_message.rocket_chat import RocketChatConnection
 from cosinnus.models.group import CosinnusPortal
 from cosinnus.models.tagged import LikeObject
 from cosinnus.utils.context_processors import cosinnus as cosinnus_context
@@ -179,6 +180,12 @@ def cosinnus_logout(request, **kwargs):
         (this seems to only clear the value of the cookie and not completely delete it!).
         Will redirect to a "you have been logged out" page, that may perform additional 
         JS queries or redirects to log out from other services. """
+    if settings.COSINNUS_ROCKET_ENABLED:
+        user_rc_uid = request.COOKIES.get('rc_session_uid')
+        user_rc_token = request.COOKIES.get('rc_session_token')
+        if user_rc_uid and user_rc_token:
+            rocket = RocketChatConnection()
+            rocket.logout_user_session(user_rc_uid, user_rc_token)
     response = LogoutView.as_view(**kwargs)(request) # logout(request, **kwargs)
     if not request.user.is_authenticated:
         response.delete_cookie('wp_user_logged_in')

--- a/cosinnus_message/conf.py
+++ b/cosinnus_message/conf.py
@@ -127,7 +127,16 @@ class CosinnusMessageDefaultSettings(AppConf):
         
         # User Surveys
         'NPS_survey_enabled': False,
-        
+
+        # Custom login script copying the Rocketchat session cookies to the top level domain. This makes the cookies
+        # available in the logout view and is used to log out the user from the Rocketchat session.
+        'Custom_Script_Logged_In': '''
+            const rcUid = document.cookie.split("; ").find((row) => row.startsWith("rc_uid="))?.split("=")[1];
+            const rcToken = document.cookie.split("; ").find((row) => row.startsWith("rc_token="))?.split("=")[1];
+            document.cookie = 'rc_session_uid=' + rcUid + ';domain=%(COSINNUS_CHAT_SESSION_COOKIE_DOMAIN)s;path=/';
+            document.cookie = 'rc_session_token=' + rcToken + ';domain=%(COSINNUS_CHAT_SESSION_COOKIE_DOMAIN)s;path=/';
+        ''',
+
         # TODO: this setting needs to be added, but under API url:
         #    https://chat.<server>/api/v1/method.call/authorization:removeRoleFromPermission
         # 'authorization:removeRoleFromPermission': ["add-user-to-joined-room","moderator"],

--- a/cosinnus_message/rocket_chat.py
+++ b/cosinnus_message/rocket_chat.py
@@ -1297,7 +1297,15 @@ class RocketChatConnection:
             logger.error('RocketChat: set_user_email_preference did not receive a success response: ' + response.get('errorType', '<No Error Type>'), extra={'response': response})
             return False
         return True
-        
+
+    def logout_user_session(self, user_id, user_token):
+        """ Logges out a user from an active session using the users user_id and auth_token """
+        user_session_connection = RocketChat(
+            user_id=user_id, auth_token=user_token, server_url=settings.COSINNUS_CHAT_BASE_URL,
+            timeout=settings.COSINNUS_CHAT_USER_CONNECTION_TIMEOUT
+        )
+        user_session_connection.logout()
+
     def _get_user_connection(self, user):
         """ Returns a user-specific rocketchat connection for the given user, 
             or None if this fails for any reason """


### PR DESCRIPTION
Implementations details:

- Add a custom login script to rocket chat, that copies the session cookies setting the domain to the portals top-level domain. This makes the rocket chat session information available in the portal backend.
- Use the rocket chat API to logout a user session using the session information from the cookies when logging out from the platform. 