### PR TITLE
Add setting to enable the custom home block on RC version 6

### DIFF
--- a/cosinnus_message/conf.py
+++ b/cosinnus_message/conf.py
@@ -101,6 +101,7 @@ class CosinnusMessageDefaultSettings(AppConf):
         'Accounts_TwoFactorAuthentication_Enabled': False,
 
         # Layout
+        'Layout_Home_Custom_Block_Visible': True,
         'Layout_Home_Body': '''<p>Willkommen beim %(COSINNUS_BASE_PAGE_TITLE_TRANS)s Rocket.Chat!</p>
 
         <p>Schreibt private Nachrichten im Browser, per Smartphone- oder Desktop-App in Echtzeit an andere, in Projekten und Gruppen oder in eigenen Kanälen.</p>


### PR DESCRIPTION
Need to set "Show custom content to homepage" in RC version 6 to see the custom home page content.

Just adding this setting. This will error if syncing settings with older RC versions. If needed, we could consider defining version-specific settings.