### PR TITLE
Navigation API spaces & bookmarks endpoints

### DIFF
--- a/cosinnus/api_frontend/views/navigation.py
+++ b/cosinnus/api_frontend/views/navigation.py
@@ -1,0 +1,168 @@
+from annoying.functions import get_object_or_None
+from django.urls.base import reverse
+from drf_yasg import openapi
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.renderers import BrowsableAPIRenderer
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from cosinnus import VERSION as COSINNUS_VERSION
+from cosinnus.api_frontend.handlers.renderers import CosinnusAPIFrontendJSONResponseRenderer
+from cosinnus.api_frontend.views.user import CsrfExemptSessionAuthentication
+from cosinnus.conf import settings
+from cosinnus.models.group import get_cosinnus_group_model, CosinnusPortal
+from cosinnus.models.group_extra import CosinnusConference
+from cosinnus.models.user_dashboard import DashboardItem, MenuItem
+from cosinnus.trans.group import CosinnusConferenceTrans, CosinnusProjectTrans, CosinnusSocietyTrans
+from cosinnus.utils.permissions import check_user_can_create_conferences, check_user_can_create_groups
+from cosinnus.views.user_dashboard import MyGroupsClusteredMixin
+
+
+class SpacesView(MyGroupsClusteredMixin, APIView):
+    """ An endpoint that returns the user spaces for the main navigation. """
+    # TODO: Make names translateble, consider adding to cosinnus.trans.group.
+    # TODO: Allow to configure community space names, e.g. using "discover" instead of "map".
+
+    permission_classes = (IsAuthenticated,)
+    renderer_classes = (CosinnusAPIFrontendJSONResponseRenderer, BrowsableAPIRenderer,)
+    authentication_classes = (CsrfExemptSessionAuthentication,)
+
+    # todo: generate proper response, by either putting the entire response into a
+    #       Serializer, or defining it by hand
+    #       Note: Also needs docs on our custom data/timestamp/version wrapper!
+    # see:  https://drf-yasg.readthedocs.io/en/stable/custom_spec.html
+    # see:  https://drf-yasg.readthedocs.io/en/stable/drf_yasg.html?highlight=Response#drf_yasg.openapi.Schema
+    @swagger_auto_schema(
+        responses={'200': openapi.Response(
+            description='WIP: Response info missing. Short example included',
+            examples={
+                "application/json": {
+                    "data": {
+                        "personal": {
+                            "items": [
+                                {
+                                    "icon": "fa-user",
+                                    "label": "Personal Dashboard",
+                                    "url": "http://localhost:8000/dashboard/"
+                                }
+                            ],
+                            "actions": []
+                        },
+                        "groups": {
+                            "items": [
+                                {
+                                    "icon": "fa-sitemap",
+                                    "label": "Test Group",
+                                    "url": "http://localhost:8000/group/test-group/"
+                                }
+                            ],
+                            "actions": [
+                                {
+                                    "icon": "",
+                                    "label": "create a new group",
+                                    "url": "http://localhost:8000/groups/add/"
+                                },
+                                {
+                                    "icon": "",
+                                    "label": "create a new project",
+                                    "url": "http://localhost:8000/projects/add/"
+                                }
+                            ]
+                        },
+                        "community": {
+                            "items": [
+                                {
+                                    "icon": "fa-sitemap",
+                                    "label": "Forum",
+                                    "url": "http://localhost:8000/group/forum/"
+                                },
+                                {
+                                    "icon": "fa-group",
+                                    "label": "Map",
+                                    "url": "http://localhost:8000/map/"
+                                }
+                            ],
+                            "actions": []
+                        },
+                        "conference": {
+                            "items": [
+                                {
+                                    "icon": "fa-television",
+                                    "label": "Test Conference",
+                                    "url": "http://localhost:8000/conference/test-conference/"
+                                }
+                            ],
+                            "actions": [
+                                {
+                                    "icon": "",
+                                    "label": "create a new conference",
+                                    "url": "http://localhost:8000/conferences/add/"
+                                }
+                            ]
+                        }
+                    },
+                    "version": COSINNUS_VERSION,
+                    "timestamp": 1658414865.057476
+                }
+            }
+        )}
+    )
+    def get(self, request):
+        spaces = {}
+
+        # personal space
+        personal_space = {
+            'items': [MenuItem('Personal Dashboard', reverse('cosinnus:user-dashboard'), 'fa-user')],
+            'actions': [],
+        }
+        spaces['personal'] = personal_space
+
+        # projects and groups
+        group_space_items = [
+            dashboard_item.as_menu_item()
+            for cluster in self.get_group_clusters(request.user) for dashboard_item in cluster
+        ]
+        group_space_actions = []
+        if check_user_can_create_groups(request.user):
+            group_space_actions = [
+                MenuItem(CosinnusSocietyTrans.CREATE_NEW, reverse('cosinnus:group__group-add')),
+                MenuItem(CosinnusProjectTrans.CREATE_NEW, reverse('cosinnus:group-add')),
+            ]
+        groups_space = {
+            'items': group_space_items,
+            'actions': group_space_actions,
+        }
+        spaces['groups'] = groups_space
+
+        # community
+        community_space_items = []
+        forum_slug = getattr(settings, 'NEWW_FORUM_GROUP_SLUG', None)
+        if forum_slug:
+            forum_group = get_object_or_None(get_cosinnus_group_model(), slug=forum_slug, portal=CosinnusPortal.get_current())
+            if forum_group:
+                community_space_items.append(
+                    MenuItem('Forum', forum_group.get_absolute_url(), 'fa-sitemap')
+                )
+        community_space_items.append(MenuItem('Map', reverse('cosinnus:map'), 'fa-group'))
+        community_space = {
+            'items': community_space_items,
+            'actions': [],
+        }
+        spaces['community'] = community_space
+
+        # conferences
+        if settings.COSINNUS_CONFERENCES_ENABLED:
+            conferences = CosinnusConference.objects.get_for_user(request.user)
+            conference_space_actions = []
+            if check_user_can_create_conferences(request.user):
+                conference_space_actions = [
+                    MenuItem(CosinnusConferenceTrans.CREATE_NEW, reverse('cosinnus:conference__group-add')),
+                ]
+            conference_space = {
+                'items': [DashboardItem(conference).as_menu_item() for conference in conferences],
+                'actions': conference_space_actions,
+            }
+            spaces['conference'] = conference_space
+
+        return Response(spaces)

--- a/cosinnus/models/user_dashboard.py
+++ b/cosinnus/models/user_dashboard.py
@@ -11,7 +11,7 @@ from cosinnus.models.tagged import BaseTaggableObjectModel
 from cosinnus.utils.group import get_cosinnus_group_model, \
     get_default_user_group_slugs
 
-import logging
+from cosinnus.models import CosinnusPortal, get_domain_for_portal
 from cosinnus.models.idea import CosinnusIdea
 from django.urls.base import reverse
 from cosinnus.models.profile import BaseUserProfile
@@ -89,3 +89,17 @@ class DashboardItem(dict):
                             self['subtext'] = date_dict
                         else:
                             self['subtext'] = date_dict.get('date')
+
+    def as_menu_item(self):
+        return MenuItem(self['text'], self['url'], self['icon'])
+
+
+class MenuItem(dict):
+
+    def __init__(self, label, url, icon=""):
+        if url and url[0] == '/':
+            domain = get_domain_for_portal(CosinnusPortal.get_current())
+            url = domain + url
+        self['icon'] = icon
+        self['label'] = label
+        self['url'] = url

--- a/cosinnus/tests/view_tests/test_navigation_api.py
+++ b/cosinnus/tests/view_tests/test_navigation_api.py
@@ -4,7 +4,9 @@ from rest_framework.test import APITestCase
 
 from cosinnus.conf import settings
 from cosinnus.models.group_extra import CosinnusSociety
+from cosinnus.models.idea import CosinnusIdea
 from cosinnus.models.membership import MEMBERSHIP_MEMBER
+from cosinnus.models.tagged import LikeObject
 
 
 User = get_user_model()
@@ -81,4 +83,51 @@ class SpacesTestView(APITestCase):
                 ],
                 'actions': []
             }
+        )
+
+
+class BookmarksTestView(APITestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.bookmarks_url = reverse("cosinnus:frontend-api:api-navigation-bookmarks")
+        cls.test_user = User.objects.create(**TEST_USER_DATA)
+
+    def test_login_required(self):
+        response = self.client.get(self.bookmarks_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_group_bookmarks(self):
+        group = CosinnusSociety.objects.create(name='Test Group')
+        LikeObject.objects.create(target_object=group, user=self.test_user, starred=True)
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.bookmarks_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertListEqual(
+            response.data['groups'],
+            [{'icon': 'fa-sitemap', 'label': 'Test Group', 'url': 'http://default domain/group/test-group/'}]
+        )
+
+    def test_user_bookmarks(self):
+        TEST_USER_DATA.update({'username': '2', 'email': 'testuser2@example.com', 'last_name': 'User2'})
+        user2 = User.objects.create(**TEST_USER_DATA)
+        LikeObject.objects.create(target_object=user2.cosinnus_profile, user=self.test_user, starred=True)
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.bookmarks_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertListEqual(
+            response.data['users'],
+            [{'icon': 'fa-user', 'label': 'Test User2', 'url': 'http://default domain/user/2/'}]
+        )
+
+    def test_content_bookmarks(self):
+        idea = CosinnusIdea.objects.create(title='Test Idea')
+        LikeObject.objects.create(target_object=idea, user=self.test_user, starred=True)
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.bookmarks_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertListEqual(
+            response.data['content'],
+            [{'icon': 'fa-lightbulb-o', 'label': 'Test Idea', 'url': 'http://default domain/map/?item=1.ideas.test-idea'}]
         )

--- a/cosinnus/tests/view_tests/test_navigation_api.py
+++ b/cosinnus/tests/view_tests/test_navigation_api.py
@@ -1,0 +1,84 @@
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from cosinnus.conf import settings
+from cosinnus.models.group_extra import CosinnusSociety
+from cosinnus.models.membership import MEMBERSHIP_MEMBER
+
+
+User = get_user_model()
+
+
+TEST_USER_DATA = {
+    'username': '1',
+    'email': 'testuser@example.com',
+    'first_name': 'Test',
+    'last_name': 'User'
+}
+
+
+class SpacesTestView(APITestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.spaces_url = reverse("cosinnus:frontend-api:api-navigation-spaces")
+        cls.test_user = User.objects.create(**TEST_USER_DATA)
+
+    def test_login_required(self):
+        response = self.client.get(self.spaces_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_personal_space(self):
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.spaces_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.data['personal'],
+            {
+                'items': [
+                    {
+                        'icon': 'fa-user',
+                        'label': 'Personal Dashboard',
+                        'url': 'http://default domain/dashboard/'
+                    }
+                ],
+                'actions': []
+            }
+        )
+
+    def test_group_space(self):
+        group = CosinnusSociety.objects.create(name='Test Group')
+        group.memberships.create(user=self.test_user, status=MEMBERSHIP_MEMBER)
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.spaces_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.data['groups'],
+            {
+                'items': [
+                    {'icon': 'fa-sitemap', 'label': 'Test Group', 'url': 'http://default domain/group/test-group/'}
+                ],
+                'actions': [
+                     {'icon': '', 'label': 'Create new Group', 'url': 'http://default domain/groups/add/'},
+                     {'icon': '', 'label': 'Create new Project', 'url': 'http://default domain/projects/add/'}
+                 ]
+            }
+        )
+
+    def test_community_space(self):
+        CosinnusSociety.objects.create(slug=settings.NEWW_FORUM_GROUP_SLUG, name='Forum')
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.spaces_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.data['community'],
+            {
+                'items': [
+                    {'icon': 'fa-sitemap', 'label': 'Forum', 'url': 'http://default domain/group/forum/'},
+                    {'icon': 'fa-group', 'label': 'Map', 'url': 'http://default domain/map/'}
+                ],
+                'actions': []
+            }
+        )

--- a/cosinnus/urls_api_frontend.py
+++ b/cosinnus/urls_api_frontend.py
@@ -5,6 +5,7 @@ from django.conf.urls import url
 
 from cosinnus.api_frontend.views.user import LoginView, SignupView, UserProfileView,\
     LogoutView
+from cosinnus.api_frontend.views.navigation import SpacesView
 from cosinnus.core.registries.group_models import group_model_registry
 from cosinnus.api_frontend.views.portal import PortalTopicsView,\
     PortalManagedTagsView, PortalTagsView, PortalUserprofileDynamicFieldsView,\
@@ -25,13 +26,12 @@ urlpatterns += [
     url(r'^api/v3/logout/$', LogoutView.as_view(), name='api-logout'),
     url(r'^api/v3/signup/$', SignupView.as_view(), name='api-signup'),
     url(r'^api/v3/user/profile/$', UserProfileView.as_view(), name='api-user-profile'),
-    
+
     url(r'^api/v3/portal/topics/$', PortalTopicsView.as_view(), name='api-portal-topics'),
     url(r'^api/v3/portal/tags/$', PortalTagsView.as_view(), name='api-portal-tags'),
     url(r'^api/v3/portal/managed_tags/$', PortalManagedTagsView.as_view(), name='api-portal-managed-tags'),
     url(r'^api/v3/portal/userprofile_dynamicfields/signup/$', PortalUserprofileDynamicFieldsSignupView.as_view(), name='api-portal-userprofile-dynamicfields-signup'),
     url(r'^api/v3/portal/userprofile_dynamicfields/$', PortalUserprofileDynamicFieldsView.as_view(), name='api-portal-userprofile-dynamicfields'),
-    
-    
-    
+
+    url(r'^api/v3/navigation/spaces/$', SpacesView.as_view(), name='api-navigation-spaces'),
 ]

--- a/cosinnus/urls_api_frontend.py
+++ b/cosinnus/urls_api_frontend.py
@@ -5,7 +5,7 @@ from django.conf.urls import url
 
 from cosinnus.api_frontend.views.user import LoginView, SignupView, UserProfileView,\
     LogoutView
-from cosinnus.api_frontend.views.navigation import SpacesView
+from cosinnus.api_frontend.views.navigation import BookmarksView, SpacesView
 from cosinnus.core.registries.group_models import group_model_registry
 from cosinnus.api_frontend.views.portal import PortalTopicsView,\
     PortalManagedTagsView, PortalTagsView, PortalUserprofileDynamicFieldsView,\
@@ -34,4 +34,5 @@ urlpatterns += [
     url(r'^api/v3/portal/userprofile_dynamicfields/$', PortalUserprofileDynamicFieldsView.as_view(), name='api-portal-userprofile-dynamicfields'),
 
     url(r'^api/v3/navigation/spaces/$', SpacesView.as_view(), name='api-navigation-spaces'),
+    url(r'^api/v3/navigation/bookmarks/$', BookmarksView.as_view(), name='api-navigation-bookmarks'),
 ]

--- a/cosinnus_event/hooks.py
+++ b/cosinnus_event/hooks.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from cosinnus.core import signals
 from cosinnus.models.bbb_room import BBBRoom
 from django.dispatch.dispatcher import receiver
+from cosinnus.conf import settings
 from cosinnus_event.models import Event, ConferenceEvent
 from threading import Thread
 from cosinnus.models.group import MEMBER_STATUS, MEMBERSHIP_ADMIN
@@ -40,11 +41,11 @@ def update_bbb_room_memberships(group_membership, deleted):
 def group_membership_has_changed_sub(sender, instance, deleted, **kwargs):
     """ Called after a CosinusGroupMembership is changed, to threaded apply membership permission
         changes to BBBRoom of all events in this group """
-    
-    class CreateBBBRoomUpdateThread(Thread):
-        def run(self):
-            update_bbb_room_memberships(instance, deleted)
-    CreateBBBRoomUpdateThread().start()
+    if settings.COSINNUS_CONFERENCES_ENABLED:
+        class CreateBBBRoomUpdateThread(Thread):
+            def run(self):
+                update_bbb_room_memberships(instance, deleted)
+        CreateBBBRoomUpdateThread().start()
 
 
 @receiver(signals.group_saved_in_form)


### PR DESCRIPTION
Add the spaces and bookmarks API endpoints for the main navigation.

Notes:
- Added a MenuItem dict to be used as serializer for menu entries and a conversion from `DashboardItem`.
- Refactored `cosinnus.views.user_dashboard` moving the functionality to get starred users and objects from the user profile, to make it reuable in the API.
- Added a check for `settings.COSINNUS_CONFERENCES_ENABLED` to `cosinnus_event.hooks.group_membership_has_changed_sub` to avoid `update_bbb_room_memberships` being called during the tests.