### PR TITLE
Navigation API: Fixup spaces endpoint & add unread messages and alerts endpoints

### DIFF
--- a/cosinnus/api_frontend/views/navigation.py
+++ b/cosinnus/api_frontend/views/navigation.py
@@ -16,6 +16,7 @@ from cosinnus.models.group_extra import CosinnusConference
 from cosinnus.models.user_dashboard import DashboardItem, MenuItem
 from cosinnus.trans.group import CosinnusConferenceTrans, CosinnusProjectTrans, CosinnusSocietyTrans
 from cosinnus.utils.permissions import check_user_can_create_conferences, check_user_can_create_groups
+from cosinnus.utils.user import get_unread_message_count_for_user
 from cosinnus.views.user_dashboard import MyGroupsClusteredMixin
 
 
@@ -168,7 +169,7 @@ class SpacesView(MyGroupsClusteredMixin, APIView):
         return Response(spaces)
 
 
-class BookmarksView(MyGroupsClusteredMixin, APIView):
+class BookmarksView(APIView):
     """ An endpoint that returns the user bookmarks for the main navigation. """
 
     permission_classes = (IsAuthenticated,)
@@ -231,3 +232,39 @@ class BookmarksView(MyGroupsClusteredMixin, APIView):
             'content': content_items,
         }
         return Response(bookmarks)
+
+
+class UnreadMessagesView(APIView):
+    """ An endpoint that returns the user unread messages for the main navigation. """
+
+    permission_classes = (IsAuthenticated,)
+    renderer_classes = (CosinnusAPIFrontendJSONResponseRenderer, BrowsableAPIRenderer,)
+    authentication_classes = (CsrfExemptSessionAuthentication,)
+
+    # todo: generate proper response, by either putting the entire response into a
+    #       Serializer, or defining it by hand
+    #       Note: Also needs docs on our custom data/timestamp/version wrapper!
+    # see:  https://drf-yasg.readthedocs.io/en/stable/custom_spec.html
+    # see:  https://drf-yasg.readthedocs.io/en/stable/drf_yasg.html?highlight=Response#drf_yasg.openapi.Schema
+    @swagger_auto_schema(
+        responses={'200': openapi.Response(
+            description='WIP: Response info missing. Short example included',
+            examples={
+                "application/json": {
+                    "data": {
+                        "count": 10
+                    },
+                    "version": COSINNUS_VERSION,
+                    "timestamp": 1658414865.057476
+                }
+            }
+        )}
+    )
+    def get(self, request):
+        unread_message_count = get_unread_message_count_for_user(request.user)
+        unread_messages = {
+            'count': unread_message_count,
+        }
+        return Response(unread_messages)
+
+

--- a/cosinnus/api_frontend/views/navigation.py
+++ b/cosinnus/api_frontend/views/navigation.py
@@ -45,7 +45,8 @@ class SpacesView(MyGroupsClusteredMixin, APIView):
                                 {
                                     "icon": "fa-user",
                                     "label": "Personal Dashboard",
-                                    "url": "http://localhost:8000/dashboard/"
+                                    "url": "http://localhost:8000/dashboard/",
+                                    "image": None,
                                 }
                             ],
                             "actions": []
@@ -55,19 +56,22 @@ class SpacesView(MyGroupsClusteredMixin, APIView):
                                 {
                                     "icon": "fa-sitemap",
                                     "label": "Test Group",
-                                    "url": "http://localhost:8000/group/test-group/"
+                                    "url": "http://localhost:8000/group/test-group/",
+                                    "image": None,
                                 }
                             ],
                             "actions": [
                                 {
-                                    "icon": "",
-                                    "label": "create a new group",
-                                    "url": "http://localhost:8000/groups/add/"
+                                    "icon": None,
+                                    "label": "Create a Group",
+                                    "url": "http://localhost:8000/groups/add/",
+                                    "image": None,
                                 },
                                 {
-                                    "icon": "",
-                                    "label": "create a new project",
-                                    "url": "http://localhost:8000/projects/add/"
+                                    "icon": None,
+                                    "label": "Create a Project",
+                                    "url": "http://localhost:8000/projects/add/",
+                                    "image": None,
                                 }
                             ]
                         },
@@ -76,12 +80,14 @@ class SpacesView(MyGroupsClusteredMixin, APIView):
                                 {
                                     "icon": "fa-sitemap",
                                     "label": "Forum",
-                                    "url": "http://localhost:8000/group/forum/"
+                                    "url": "http://localhost:8000/group/forum/",
+                                    "image": None,
                                 },
                                 {
                                     "icon": "fa-group",
                                     "label": "Map",
-                                    "url": "http://localhost:8000/map/"
+                                    "url": "http://localhost:8000/map/",
+                                    "image": None,
                                 }
                             ],
                             "actions": []
@@ -91,14 +97,16 @@ class SpacesView(MyGroupsClusteredMixin, APIView):
                                 {
                                     "icon": "fa-television",
                                     "label": "Test Conference",
-                                    "url": "http://localhost:8000/conference/test-conference/"
+                                    "url": "http://localhost:8000/conference/test-conference/",
+                                    "image": None,
                                 }
                             ],
                             "actions": [
                                 {
-                                    "icon": "",
-                                    "label": "create a new conference",
-                                    "url": "http://localhost:8000/conferences/add/"
+                                    "icon": None,
+                                    "label": "Create a Conference",
+                                    "url": "http://localhost:8000/conferences/add/",
+                                    "image": None,
                                 }
                             ]
                         }
@@ -113,8 +121,12 @@ class SpacesView(MyGroupsClusteredMixin, APIView):
         spaces = {}
 
         # personal space
+        dashboard_item = MenuItem(
+            'Personal Dashboard', reverse('cosinnus:user-dashboard'), 'fa-user',
+            request.user.cosinnus_profile.avatar_url
+        )
         personal_space = {
-            'items': [MenuItem('Personal Dashboard', reverse('cosinnus:user-dashboard'), 'fa-user')],
+            'items': [dashboard_item],
             'actions': [],
         }
         spaces['personal'] = personal_space
@@ -191,21 +203,24 @@ class BookmarksView(APIView):
                             {
                                 "icon": "fa-sitemap",
                                 "label": "Test Group",
-                                "url": "http://localhost:8000/group/test-group/"
+                                "url": "http://localhost:8000/group/test-group/",
+                                "image": None,
                             }
                         ],
                         "users": [
                             {
                                 "icon": "fa-user",
                                 "label": "Test User",
-                                "url": "http://localhost:8000/user/2/"
+                                "url": "http://localhost:8000/user/2/",
+                                "image": None,
                             }
                         ],
                         "content": [
                             {
                                 "icon": "fa-lightbulb-o",
                                 "label": "Test Idea",
-                                "url": "http://localhost:8000/map/?item=1.ideas.test-idea"
+                                "url": "http://localhost:8000/map/?item=1.ideas.test-idea",
+                                "image": None,
                             }
                         ]
                     },

--- a/cosinnus/models/user_dashboard.py
+++ b/cosinnus/models/user_dashboard.py
@@ -30,6 +30,7 @@ class DashboardItem(dict):
     is_emphasized = False
     group = None # group name of item if it has one
     group_icon = None # group type icon
+    avatar = None
 
     def __init__(self, obj=None, is_emphasized=False, user=None):
         if obj:
@@ -45,6 +46,7 @@ class DashboardItem(dict):
                 self['icon'] = obj.get_icon()
                 self['text'] = escape(obj.name)
                 self['url'] = obj.get_absolute_url()
+                self['avatar'] = obj.avatar_url
             elif type(obj) is CosinnusIdea:
                 self['icon'] = obj.get_icon()
                 self['text'] = escape(obj.title)
@@ -67,6 +69,7 @@ class DashboardItem(dict):
                 self['icon'] = obj.get_icon()
                 self['text'] = escape(full_name(obj.user))
                 self['url'] = obj.get_absolute_url()
+                self['avatar'] = obj.avatar_url
             elif BaseTaggableObjectModel in inspect.getmro(obj.__class__):
                 
                 
@@ -91,15 +94,18 @@ class DashboardItem(dict):
                             self['subtext'] = date_dict.get('date')
 
     def as_menu_item(self):
-        return MenuItem(self['text'], self['url'], self['icon'])
+        return MenuItem(self['text'], self['url'], self['icon'], self['avatar'] if 'avatar' in self else None)
 
 
 class MenuItem(dict):
 
-    def __init__(self, label, url, icon=""):
+    def __init__(self, label, url, icon=None, image=None):
+        domain = get_domain_for_portal(CosinnusPortal.get_current())
         if url and url[0] == '/':
-            domain = get_domain_for_portal(CosinnusPortal.get_current())
             url = domain + url
         self['icon'] = icon
         self['label'] = label
         self['url'] = url
+        if image and image[0] == '/':
+            image = domain + image
+        self['image'] = image

--- a/cosinnus/tests/view_tests/test_navigation_api.py
+++ b/cosinnus/tests/view_tests/test_navigation_api.py
@@ -44,7 +44,8 @@ class SpacesTestView(APITestCase):
                     {
                         'icon': 'fa-user',
                         'label': 'Personal Dashboard',
-                        'url': 'http://default domain/dashboard/'
+                        'url': 'http://default domain/dashboard/',
+                        'image': None,
                     }
                 ],
                 'actions': []
@@ -61,11 +62,14 @@ class SpacesTestView(APITestCase):
             response.data['groups'],
             {
                 'items': [
-                    {'icon': 'fa-sitemap', 'label': 'Test Group', 'url': 'http://default domain/group/test-group/'}
+                    {'icon': 'fa-sitemap', 'label': 'Test Group', 'url': 'http://default domain/group/test-group/',
+                     'image': None}
                 ],
                 'actions': [
-                     {'icon': '', 'label': 'Create new Group', 'url': 'http://default domain/groups/add/'},
-                     {'icon': '', 'label': 'Create new Project', 'url': 'http://default domain/projects/add/'}
+                     {'icon': None, 'label': 'Create new Group', 'url': 'http://default domain/groups/add/',
+                      'image': None},
+                     {'icon': None, 'label': 'Create new Project', 'url': 'http://default domain/projects/add/',
+                      'image': None}
                  ]
             }
         )
@@ -79,8 +83,9 @@ class SpacesTestView(APITestCase):
             response.data['community'],
             {
                 'items': [
-                    {'icon': 'fa-sitemap', 'label': 'Forum', 'url': 'http://default domain/group/forum/'},
-                    {'icon': 'fa-group', 'label': 'Map', 'url': 'http://default domain/map/'}
+                    {'icon': 'fa-sitemap', 'label': 'Forum', 'url': 'http://default domain/group/forum/',
+                     'image': None},
+                    {'icon': 'fa-group', 'label': 'Map', 'url': 'http://default domain/map/', 'image': None}
                 ],
                 'actions': []
             }
@@ -88,6 +93,7 @@ class SpacesTestView(APITestCase):
 
 
 class BookmarksTestView(APITestCase):
+
 
     @classmethod
     def setUpClass(cls):
@@ -107,7 +113,10 @@ class BookmarksTestView(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertListEqual(
             response.data['groups'],
-            [{'icon': 'fa-sitemap', 'label': 'Test Group', 'url': 'http://default domain/group/test-group/'}]
+            [
+                {'icon': 'fa-sitemap', 'label': 'Test Group', 'url': 'http://default domain/group/test-group/',
+                 'image': None}
+            ]
         )
 
     def test_user_bookmarks(self):
@@ -119,7 +128,7 @@ class BookmarksTestView(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertListEqual(
             response.data['users'],
-            [{'icon': 'fa-user', 'label': 'Test User2', 'url': 'http://default domain/user/2/'}]
+            [{'icon': 'fa-user', 'label': 'Test User2', 'url': 'http://default domain/user/2/', 'image': None}]
         )
 
     def test_content_bookmarks(self):
@@ -130,7 +139,8 @@ class BookmarksTestView(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertListEqual(
             response.data['content'],
-            [{'icon': 'fa-lightbulb-o', 'label': 'Test Idea', 'url': 'http://default domain/map/?item=1.ideas.test-idea'}]
+            [{'icon': 'fa-lightbulb-o', 'label': 'Test Idea',
+              'url': 'http://default domain/map/?item=1.ideas.test-idea', 'image': None}]
         )
 
 

--- a/cosinnus/tests/view_tests/test_navigation_api.py
+++ b/cosinnus/tests/view_tests/test_navigation_api.py
@@ -1,3 +1,4 @@
+from unittest.mock import patch
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 from rest_framework.test import APITestCase
@@ -131,3 +132,24 @@ class BookmarksTestView(APITestCase):
             response.data['content'],
             [{'icon': 'fa-lightbulb-o', 'label': 'Test Idea', 'url': 'http://default domain/map/?item=1.ideas.test-idea'}]
         )
+
+
+class UnreadMessagesTestView(APITestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.unread_messages_url = reverse("cosinnus:frontend-api:api-navigation-unread-messages")
+        cls.test_user = User.objects.create(**TEST_USER_DATA)
+
+    def test_login_required(self):
+        response = self.client.get(self.unread_messages_url)
+        self.assertEqual(response.status_code, 403)
+
+    @patch('cosinnus.api_frontend.views.navigation.get_unread_message_count_for_user', return_value=10)
+    def test_unread_messages_count(self, mock):
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.unread_messages_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(response.data, {'count': 10})
+

--- a/cosinnus/tests/view_tests/test_navigation_api.py
+++ b/cosinnus/tests/view_tests/test_navigation_api.py
@@ -4,10 +4,12 @@ from django.urls import reverse
 from rest_framework.test import APITestCase
 
 from cosinnus.conf import settings
+from cosinnus.models.group import CosinnusPortal
 from cosinnus.models.group_extra import CosinnusSociety
 from cosinnus.models.idea import CosinnusIdea
 from cosinnus.models.membership import MEMBERSHIP_MEMBER
 from cosinnus.models.tagged import LikeObject
+from cosinnus_notifications.models import NotificationAlert
 
 
 User = get_user_model()
@@ -26,16 +28,16 @@ class SpacesTestView(APITestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.spaces_url = reverse("cosinnus:frontend-api:api-navigation-spaces")
+        cls.api_url = reverse("cosinnus:frontend-api:api-navigation-spaces")
         cls.test_user = User.objects.create(**TEST_USER_DATA)
 
     def test_login_required(self):
-        response = self.client.get(self.spaces_url)
+        response = self.client.get(self.api_url)
         self.assertEqual(response.status_code, 403)
 
     def test_personal_space(self):
         self.client.force_login(self.test_user)
-        response = self.client.get(self.spaces_url)
+        response = self.client.get(self.api_url)
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
             response.data['personal'],
@@ -56,7 +58,7 @@ class SpacesTestView(APITestCase):
         group = CosinnusSociety.objects.create(name='Test Group')
         group.memberships.create(user=self.test_user, status=MEMBERSHIP_MEMBER)
         self.client.force_login(self.test_user)
-        response = self.client.get(self.spaces_url)
+        response = self.client.get(self.api_url)
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
             response.data['groups'],
@@ -77,7 +79,7 @@ class SpacesTestView(APITestCase):
     def test_community_space(self):
         CosinnusSociety.objects.create(slug=settings.NEWW_FORUM_GROUP_SLUG, name='Forum')
         self.client.force_login(self.test_user)
-        response = self.client.get(self.spaces_url)
+        response = self.client.get(self.api_url)
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(
             response.data['community'],
@@ -98,18 +100,18 @@ class BookmarksTestView(APITestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.bookmarks_url = reverse("cosinnus:frontend-api:api-navigation-bookmarks")
+        cls.api_url = reverse("cosinnus:frontend-api:api-navigation-bookmarks")
         cls.test_user = User.objects.create(**TEST_USER_DATA)
 
     def test_login_required(self):
-        response = self.client.get(self.bookmarks_url)
+        response = self.client.get(self.api_url)
         self.assertEqual(response.status_code, 403)
 
     def test_group_bookmarks(self):
         group = CosinnusSociety.objects.create(name='Test Group')
         LikeObject.objects.create(target_object=group, user=self.test_user, starred=True)
         self.client.force_login(self.test_user)
-        response = self.client.get(self.bookmarks_url)
+        response = self.client.get(self.api_url)
         self.assertEqual(response.status_code, 200)
         self.assertListEqual(
             response.data['groups'],
@@ -124,7 +126,7 @@ class BookmarksTestView(APITestCase):
         user2 = User.objects.create(**TEST_USER_DATA)
         LikeObject.objects.create(target_object=user2.cosinnus_profile, user=self.test_user, starred=True)
         self.client.force_login(self.test_user)
-        response = self.client.get(self.bookmarks_url)
+        response = self.client.get(self.api_url)
         self.assertEqual(response.status_code, 200)
         self.assertListEqual(
             response.data['users'],
@@ -135,7 +137,7 @@ class BookmarksTestView(APITestCase):
         idea = CosinnusIdea.objects.create(title='Test Idea')
         LikeObject.objects.create(target_object=idea, user=self.test_user, starred=True)
         self.client.force_login(self.test_user)
-        response = self.client.get(self.bookmarks_url)
+        response = self.client.get(self.api_url)
         self.assertEqual(response.status_code, 200)
         self.assertListEqual(
             response.data['content'],
@@ -149,17 +151,43 @@ class UnreadMessagesTestView(APITestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.unread_messages_url = reverse("cosinnus:frontend-api:api-navigation-unread-messages")
+        cls.api_url = reverse("cosinnus:frontend-api:api-navigation-unread-messages")
         cls.test_user = User.objects.create(**TEST_USER_DATA)
 
     def test_login_required(self):
-        response = self.client.get(self.unread_messages_url)
+        response = self.client.get(self.api_url)
         self.assertEqual(response.status_code, 403)
 
     @patch('cosinnus.api_frontend.views.navigation.get_unread_message_count_for_user', return_value=10)
-    def test_unread_messages_count(self, mock):
+    def test_unread_messages_count(self, get_unread_message_count_for_user_patch):
         self.client.force_login(self.test_user)
-        response = self.client.get(self.unread_messages_url)
+        response = self.client.get(self.api_url)
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.data, {'count': 10})
 
+
+class UnreadAlertsTestView(APITestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.api_url = reverse("cosinnus:frontend-api:api-navigation-unread-alerts")
+        cls.test_user = User.objects.create(**TEST_USER_DATA)
+        cls.portal = CosinnusPortal.get_current()
+
+    def test_login_required(self):
+        response = self.client.get(self.api_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_unread_alerts_count(self):
+        group = CosinnusSociety.objects.create(name='Test Group')
+        notification_alert_init_data = {
+            'user': self.test_user, 'target_object':group, 'action_user':self.test_user, 'portal':self.portal
+        }
+        NotificationAlert.objects.create(seen=True, **notification_alert_init_data)
+        NotificationAlert.objects.create(seen=False, **notification_alert_init_data)
+        NotificationAlert.objects.create(seen=False, **notification_alert_init_data)
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.api_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(response.data, {'count': 2})

--- a/cosinnus/urls_api_frontend.py
+++ b/cosinnus/urls_api_frontend.py
@@ -5,7 +5,7 @@ from django.conf.urls import url
 
 from cosinnus.api_frontend.views.user import LoginView, SignupView, UserProfileView,\
     LogoutView
-from cosinnus.api_frontend.views.navigation import BookmarksView, SpacesView
+from cosinnus.api_frontend.views.navigation import BookmarksView, SpacesView, UnreadMessagesView
 from cosinnus.core.registries.group_models import group_model_registry
 from cosinnus.api_frontend.views.portal import PortalTopicsView,\
     PortalManagedTagsView, PortalTagsView, PortalUserprofileDynamicFieldsView,\
@@ -35,4 +35,5 @@ urlpatterns += [
 
     url(r'^api/v3/navigation/spaces/$', SpacesView.as_view(), name='api-navigation-spaces'),
     url(r'^api/v3/navigation/bookmarks/$', BookmarksView.as_view(), name='api-navigation-bookmarks'),
+    url(r'^api/v3/navigation/unread_messages/$', UnreadMessagesView.as_view(), name='api-navigation-unread-messages'),
 ]

--- a/cosinnus/urls_api_frontend.py
+++ b/cosinnus/urls_api_frontend.py
@@ -5,7 +5,7 @@ from django.conf.urls import url
 
 from cosinnus.api_frontend.views.user import LoginView, SignupView, UserProfileView,\
     LogoutView
-from cosinnus.api_frontend.views.navigation import BookmarksView, SpacesView, UnreadMessagesView
+from cosinnus.api_frontend.views.navigation import BookmarksView, SpacesView, UnreadMessagesView, UnreadAlertsView
 from cosinnus.core.registries.group_models import group_model_registry
 from cosinnus.api_frontend.views.portal import PortalTopicsView,\
     PortalManagedTagsView, PortalTagsView, PortalUserprofileDynamicFieldsView,\
@@ -36,4 +36,5 @@ urlpatterns += [
     url(r'^api/v3/navigation/spaces/$', SpacesView.as_view(), name='api-navigation-spaces'),
     url(r'^api/v3/navigation/bookmarks/$', BookmarksView.as_view(), name='api-navigation-bookmarks'),
     url(r'^api/v3/navigation/unread_messages/$', UnreadMessagesView.as_view(), name='api-navigation-unread-messages'),
+    url(r'^api/v3/navigation/unread_alerts/$', UnreadAlertsView.as_view(), name='api-navigation-unread-alerts'),
 ]


### PR DESCRIPTION
Followup PR for: https://github.com/wechange-eg/cosinnus-core/pull/323

Contains:
- Fixup for spaces + bookmarks endpoints:
  - Add "image" field to dashboard-item and menu-item and set it to avatar if exists
  - Use `null` instead of `""` for empty fields
- Add unread messages API endpoint
- Add unread alerts API endpoint