### PR TITLE
Add alerts, help and profile navigation API endpoints & minor API fixups

### DIFF
--- a/cosinnus/api_frontend/views/navigation.py
+++ b/cosinnus/api_frontend/views/navigation.py
@@ -1,8 +1,10 @@
 from annoying.functions import get_object_or_None
+from django.contrib.auth import get_user_model
 from django.db.models import Case, Count, When
 from django.urls.base import reverse
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.renderers import BrowsableAPIRenderer
 from rest_framework.response import Response
@@ -16,10 +18,12 @@ from cosinnus.models.group import get_cosinnus_group_model, CosinnusPortal
 from cosinnus.models.group_extra import CosinnusConference
 from cosinnus.models.user_dashboard import DashboardItem, MenuItem
 from cosinnus.trans.group import CosinnusConferenceTrans, CosinnusProjectTrans, CosinnusSocietyTrans
-from cosinnus.utils.permissions import check_user_can_create_conferences, check_user_can_create_groups
+from cosinnus.utils.dates import datetime_from_timestamp, timestamp_from_datetime
+from cosinnus.utils.permissions import check_user_can_create_conferences, check_user_can_create_groups, \
+    check_user_portal_manager
 from cosinnus.utils.user import get_unread_message_count_for_user
 from cosinnus.views.user_dashboard import MyGroupsClusteredMixin
-from cosinnus_notifications.models import NotificationAlert
+from cosinnus_notifications.models import NotificationAlert, SerializedNotificationAlert
 
 
 class SpacesView(MyGroupsClusteredMixin, APIView):
@@ -155,11 +159,14 @@ class SpacesView(MyGroupsClusteredMixin, APIView):
         forum_slug = getattr(settings, 'NEWW_FORUM_GROUP_SLUG', None)
         if forum_slug:
             forum_group = get_object_or_None(get_cosinnus_group_model(), slug=forum_slug, portal=CosinnusPortal.get_current())
-            if forum_group:
+            if forum_group and settings.COSINNUS_V3_MENU_SPACES_FORUM_LABEL:
                 community_space_items.append(
-                    MenuItem('Forum', forum_group.get_absolute_url(), 'fa-sitemap')
+                    MenuItem(settings.COSINNUS_V3_MENU_SPACES_FORUM_LABEL, forum_group.get_absolute_url(), 'fa-sitemap')
                 )
-        community_space_items.append(MenuItem('Map', reverse('cosinnus:map'), 'fa-group'))
+        if settings.COSINNUS_V3_MENU_SPACES_MAP_LABEL:
+            community_space_items.append(
+                MenuItem(settings.COSINNUS_V3_MENU_SPACES_MAP_LABEL, reverse('cosinnus:map'), 'fa-group')
+            )
         community_space = {
             'items': community_space_items,
             'actions': [],
@@ -252,7 +259,7 @@ class BookmarksView(APIView):
 
 
 class UnreadMessagesView(APIView):
-    """ An endpoint that returns the user unread messages for the main navigation. """
+    """ An endpoint that returns the user unread message count for the main navigation. """
 
     permission_classes = (IsAuthenticated,)
     renderer_classes = (CosinnusAPIFrontendJSONResponseRenderer, BrowsableAPIRenderer,)
@@ -286,7 +293,7 @@ class UnreadMessagesView(APIView):
 
 
 class UnreadAlertsView(APIView):
-    """ An endpoint that returns the user unseen alerts for the main navigation. """
+    """ An endpoint that returns the user unseen alerts count for the main navigation. """
 
     permission_classes = (IsAuthenticated,)
     renderer_classes = (CosinnusAPIFrontendJSONResponseRenderer, BrowsableAPIRenderer,)
@@ -318,3 +325,275 @@ class UnreadAlertsView(APIView):
             'count': unseen_aggr.get('seen_count', 0)
         }
         return Response(unread_alerts)
+
+
+class AlertsView(APIView):
+    """ An endpoint that returns the user alerts for the main navigation. """
+    # TODO: consider caching.
+    # TODO: discuss pagination, newer_than_timestamp, offset_timestamp.
+    # TODO: discuss limiting the fields to data needed by the frontend.
+
+    permission_classes = (IsAuthenticated,)
+    renderer_classes = (CosinnusAPIFrontendJSONResponseRenderer, BrowsableAPIRenderer,)
+    authentication_classes = (CsrfExemptSessionAuthentication,)
+
+    # todo: generate proper response, by either putting the entire response into a
+    #       Serializer, or defining it by hand
+    #       Note: Also needs docs on our custom data/timestamp/version wrapper!
+    # see:  https://drf-yasg.readthedocs.io/en/stable/custom_spec.html
+    # see:  https://drf-yasg.readthedocs.io/en/stable/drf_yasg.html?highlight=Response#drf_yasg.openapi.Schema
+
+    page_size = 10
+    newer_than_timestamp = None
+    offset_timestamp = None
+
+    @swagger_auto_schema(
+        manual_parameters=[
+            openapi.Parameter(
+                'newer_than_timestamp', openapi.IN_QUERY, required=False,
+                description='Return alerts newer then this timestamp.', type=openapi.FORMAT_FLOAT
+            ),
+            openapi.Parameter(
+                'offset_timestamp', openapi.IN_QUERY, required=False,
+                description='Return alerts older then this timestamp.', type=openapi.FORMAT_FLOAT
+            ),
+        ],
+        responses={'200': openapi.Response(
+            description='WIP: Response info missing. Short example included',
+            examples={
+                "application/json": {
+                    "data": {
+                        "items": [
+                            {
+                                "text": "<b>User 2</b> created 2 news posts.",
+                                "id": 80,
+                                "url": "http://localhost:8000/group/test-group/note/1401481714/",
+                                "item_icon_or_image_url": "fa-quote-right",
+                                "user_icon_or_image_url": "/static/images/jane-doe-small.png",
+                                "group": "Test Group",
+                                "group_icon": "fa-sitemap",
+                                "action_datetime": "2023-06-08T08:49:49.965634+00:00",
+                                "is_emphasized": True,
+                                "alert_reason": "You are following this content or its Project or Group",
+                                "sub_items": [
+                                    {
+                                        "title": "test2",
+                                        "url": "http://localhost:8000/group/test-group/note/1455745550/",
+                                        "icon_or_image_url": "fa-quote-right"
+                                    },
+                                    {
+                                        "title": "test",
+                                        "url": "http://localhost:8000/group/test-group/note/1401481714/",
+                                        "icon_or_image_url": "fa-quote-right"
+                                    }
+                                ],
+                                "is_multi_user_alert": False,
+                                "is_bundle_alert": True
+                            },
+                            {
+                                "text": "<b>User 2</b> requested to become a member.",
+                                "id": 47,
+                                "url": "http://localhost:8000/group/test-group/members/",
+                                "item_icon_or_image_url": "fa-sitemap",
+                                "user_icon_or_image_url": "/static/images/jane-doe-small.png",
+                                "group": "Test Group",
+                                "group_icon": "fa-sitemap",
+                                "action_datetime": "2023-05-24T08:44:50.570918+00:00",
+                                "is_emphasized": False,
+                                "alert_reason": "You are an admin of this team",
+                                "sub_items": [],
+                                "is_multi_user_alert": False,
+                                "is_bundle_alert": False
+                            }
+                        ],
+                        "has_more": False,
+                        "offset_timestamp": 1684917890.570918,
+                        "newest_timestamp": 1686664282.772708
+                    },
+                    "version": COSINNUS_VERSION,
+                    "timestamp": 1658414865.057476
+                }
+            }
+        )},
+    )
+    def get(self, request):
+        self.read_query_params(request)
+        response = {
+            'items': None,
+            'has_more': False,
+            'offset_timestamp': None,
+            'newest_timestamp': None,
+        }
+        queryset = self.get_queryset()
+
+        # has_more
+        response['has_more'] = queryset.count() > self.page_size
+
+        # paginate
+        queryset = queryset[:self.page_size]
+        alerts = list(queryset)
+
+        # alert items
+        user_cache = self.get_user_cache(alerts)
+        items = [
+            SerializedNotificationAlert(
+                alert,
+                action_user=user_cache[alert.action_user_id][0],
+                action_user_profile=user_cache[alert.action_user_id][1],
+            ) for alert in alerts
+        ]
+        response['items'] = items
+
+        # newest timestamp
+        if not self.offset_timestamp and len(alerts) > 0:
+            newest_timestamp = timestamp_from_datetime(alerts[0].last_event_at)
+            response['newest_timestamp'] = newest_timestamp
+
+        # offset timestamp
+        if len(alerts) > 0:
+            offset_timestamp = timestamp_from_datetime(alerts[-1].last_event_at)
+            response['offset_timestamp'] = offset_timestamp
+
+        return Response(response)
+
+    def read_query_params(self, request):
+        self.newer_than_timestamp = request.query_params.get('newer_than_timestamp')
+        if self.newer_than_timestamp:
+            try:
+                self.newer_than_timestamp = float(self.newer_than_timestamp)
+            except Exception:
+                raise ValidationError({'newer_than_timestamp': 'Float timestamp expected'})
+        self.offset_timestamp = request.query_params.get('offset_timestamp')
+        if self.offset_timestamp:
+            try:
+                self.offset_timestamp= float(self.offset_timestamp)
+            except Exception:
+                raise ValidationError({'offset_timestamp': 'Float timestamp expected'})
+
+    def get_queryset(self):
+        alerts_qs = NotificationAlert.objects.filter(portal=CosinnusPortal.get_current(), user=self.request.user)
+        if self.newer_than_timestamp:
+            after_dt = datetime_from_timestamp(self.newer_than_timestamp)
+            alerts_qs = alerts_qs.filter(last_event_at__gt=after_dt)
+        elif self.offset_timestamp:
+            before_datetime = datetime_from_timestamp(self.offset_timestamp)
+            alerts_qs = alerts_qs.filter(last_event_at__lt=before_datetime)
+        if not self.newer_than_timestamp:
+            alerts_qs = alerts_qs
+        return alerts_qs
+
+    def get_user_cache(self, alerts):
+        user_ids = list(set([alert.action_user_id for alert in alerts]))
+        users = get_user_model().objects.filter(id__in=user_ids).prefetch_related('cosinnus_profile')
+        user_cache = dict(((user.id, (user, user.cosinnus_profile)) for user in users))
+        return user_cache
+
+
+class HelpView(APIView):
+    """ An endpoint that returns help menu items for the main navigation. """
+
+    renderer_classes = (CosinnusAPIFrontendJSONResponseRenderer, BrowsableAPIRenderer,)
+    authentication_classes = (CsrfExemptSessionAuthentication,)
+
+    # todo: generate proper response, by either putting the entire response into a
+    #       Serializer, or defining it by hand
+    #       Note: Also needs docs on our custom data/timestamp/version wrapper!
+    # see:  https://drf-yasg.readthedocs.io/en/stable/custom_spec.html
+    # see:  https://drf-yasg.readthedocs.io/en/stable/drf_yasg.html?highlight=Response#drf_yasg.openapi.Schema
+    @swagger_auto_schema(
+        responses={'200': openapi.Response(
+            description='WIP: Response info missing. Short example included',
+            examples={
+                "application/json": {
+                    "data": [
+                        {
+                            "icon": "fa-question-circle",
+                            "label": "<b>FAQ</b> (Frequently asked questions)",
+                            "url": "https://localhost:8000/faq/",
+                            "image": None
+                        },
+                        {
+                            "icon": "fa-life-ring",
+                            "label": "<b>Support-Channel</b> (Chat)",
+                            "url": "https://localhost:8000/support/",
+                            "image": None
+                        }
+                    ],
+                    "version": COSINNUS_VERSION,
+                    "timestamp": 1658414865.057476
+                }
+            }
+        )}
+    )
+    def get(self, request):
+        help_items = [MenuItem(label, url, icon) for label, url, icon in settings.COSINNUS_V3_MENU_HELP_LINKS]
+        return Response(help_items)
+
+
+class ProfileView(APIView):
+    """ An endpoint that returns user profile menu items for the main navigation. """
+
+    permission_classes = (IsAuthenticated,)
+    renderer_classes = (CosinnusAPIFrontendJSONResponseRenderer, BrowsableAPIRenderer,)
+    authentication_classes = (CsrfExemptSessionAuthentication,)
+
+    # todo: generate proper response, by either putting the entire response into a
+    #       Serializer, or defining it by hand
+    #       Note: Also needs docs on our custom data/timestamp/version wrapper!
+    # see:  https://drf-yasg.readthedocs.io/en/stable/custom_spec.html
+    # see:  https://drf-yasg.readthedocs.io/en/stable/drf_yasg.html?highlight=Response#drf_yasg.openapi.Schema
+    @swagger_auto_schema(
+        responses={'200': openapi.Response(
+            description='WIP: Response info missing. Short example included',
+            examples={
+                "application/json": {
+                    "data": [
+                    ],
+                    "version": COSINNUS_VERSION,
+                    "timestamp": 1658414865.057476
+                }
+            }
+        )}
+    )
+    def get(self, request):
+        profile_menu = []
+
+        # profile page
+        profile_menu_items = [
+            MenuItem('My Profile', reverse('cosinnus:profile-detail'), 'fa-circle-user'),
+            MenuItem('Set up my Profile', reverse('cosinnus:v3-frontend-setup-profile'), 'fa-pen'),
+            MenuItem('Edit my Profile', reverse('cosinnus:profile-edit'), 'fa-gear'),
+            MenuItem('Notification Preferences', reverse('cosinnus:notifications'), 'fa-envelope'),
+
+        ]
+        profile_menu.extend(profile_menu_items)
+
+        # language
+        if not settings.COSINNUS_LANGUAGE_SELECT_DISABLED:
+            language_item = MenuItem('Change Language', None, 'fa-language')
+            language_subitems = [
+                MenuItem(language, reverse('cosinnus:switch-language', kwargs={'language': code}))
+                for code, language in settings.LANGUAGES
+            ]
+            language_item['sub_items'] = language_subitems
+            profile_menu.append(language_item)
+
+        # payments
+        # TODO: consider my_contribution_badge
+        if settings.COSINNUS_PAYMENTS_ENABLED or settings.COSINNUS_PAYMENTS_ENABLED_ADMIN_ONLY \
+                and request.user.is_superuser:
+            payments_item = MenuItem('Your Contribution', reverse('wechange-payments:overview'), 'fa-hand-holding-hart')
+            profile_menu.append(payments_item)
+
+        # administration
+        if request.user.is_superuser or check_user_portal_manager(request.user):
+            administration_item = MenuItem(
+                'Administration', reverse('cosinnus:administration'), 'fa-screwdriver-wrench'
+            )
+            profile_menu.append(administration_item)
+
+        # logout
+        logout_item = MenuItem('Logout', reverse('logout'), 'fa-right-from-bracket')
+        profile_menu.append(logout_item)
+
+        return Response(profile_menu)

--- a/cosinnus/api_frontend/views/navigation.py
+++ b/cosinnus/api_frontend/views/navigation.py
@@ -2,6 +2,7 @@ from annoying.functions import get_object_or_None
 from django.contrib.auth import get_user_model
 from django.db.models import Case, Count, When
 from django.urls.base import reverse
+from django.utils.translation import ugettext_lazy as _
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.exceptions import ValidationError
@@ -128,7 +129,7 @@ class SpacesView(MyGroupsClusteredMixin, APIView):
 
         # personal space
         dashboard_item = MenuItem(
-            'Personal Dashboard', reverse('cosinnus:user-dashboard'), 'fa-user',
+            _('Personal Dashboard'), reverse('cosinnus:user-dashboard'), 'fa-user',
             request.user.cosinnus_profile.avatar_url
         )
         personal_space = {
@@ -560,17 +561,17 @@ class ProfileView(APIView):
 
         # profile page
         profile_menu_items = [
-            MenuItem('My Profile', reverse('cosinnus:profile-detail'), 'fa-circle-user'),
-            MenuItem('Set up my Profile', reverse('cosinnus:v3-frontend-setup-profile'), 'fa-pen'),
-            MenuItem('Edit my Profile', reverse('cosinnus:profile-edit'), 'fa-gear'),
-            MenuItem('Notification Preferences', reverse('cosinnus:notifications'), 'fa-envelope'),
+            MenuItem(_('My Profile'), reverse('cosinnus:profile-detail'), 'fa-circle-user'),
+            MenuItem(_('Set up my Profile'), reverse('cosinnus:v3-frontend-setup-profile'), 'fa-pen'),
+            MenuItem(_('Edit my Profile'), reverse('cosinnus:profile-edit'), 'fa-gear'),
+            MenuItem(_('Notification Preferences'), reverse('cosinnus:notifications'), 'fa-envelope'),
 
         ]
         profile_menu.extend(profile_menu_items)
 
         # language
         if not settings.COSINNUS_LANGUAGE_SELECT_DISABLED:
-            language_item = MenuItem('Change Language', None, 'fa-language')
+            language_item = MenuItem(_('Change Language'), None, 'fa-language')
             language_subitems = [
                 MenuItem(language, reverse('cosinnus:switch-language', kwargs={'language': code}))
                 for code, language in settings.LANGUAGES
@@ -582,18 +583,18 @@ class ProfileView(APIView):
         # TODO: consider my_contribution_badge
         if settings.COSINNUS_PAYMENTS_ENABLED or settings.COSINNUS_PAYMENTS_ENABLED_ADMIN_ONLY \
                 and request.user.is_superuser:
-            payments_item = MenuItem('Your Contribution', reverse('wechange-payments:overview'), 'fa-hand-holding-hart')
+            payments_item = MenuItem(_('Your Contribution'), reverse('wechange-payments:overview'), 'fa-hand-holding-hart')
             profile_menu.append(payments_item)
 
         # administration
         if request.user.is_superuser or check_user_portal_manager(request.user):
             administration_item = MenuItem(
-                'Administration', reverse('cosinnus:administration'), 'fa-screwdriver-wrench'
+                _('Administration'), reverse('cosinnus:administration'), 'fa-screwdriver-wrench'
             )
             profile_menu.append(administration_item)
 
         # logout
-        logout_item = MenuItem('Logout', reverse('logout'), 'fa-right-from-bracket')
+        logout_item = MenuItem(_('Logout'), reverse('logout'), 'fa-right-from-bracket')
         profile_menu.append(logout_item)
 
         return Response(profile_menu)

--- a/cosinnus/api_frontend/views/navigation.py
+++ b/cosinnus/api_frontend/views/navigation.py
@@ -562,11 +562,16 @@ class ProfileView(APIView):
         # profile page
         profile_menu_items = [
             MenuItem(_('My Profile'), reverse('cosinnus:profile-detail'), 'fa-circle-user'),
-            MenuItem(_('Set up my Profile'), reverse('cosinnus:v3-frontend-setup-profile'), 'fa-pen'),
+        ]
+        if settings.COSINNUS_V3_FRONTEND_ENABLED:
+            profile_menu_items.append(
+                MenuItem(_('Set up my Profile'), reverse('cosinnus:v3-frontend-setup-profile'), 'fa-pen'),
+            )
+        profile_menu_items.append([
             MenuItem(_('Edit my Profile'), reverse('cosinnus:profile-edit'), 'fa-gear'),
             MenuItem(_('Notification Preferences'), reverse('cosinnus:notifications'), 'fa-envelope'),
 
-        ]
+        ])
         profile_menu.extend(profile_menu_items)
 
         # language

--- a/cosinnus/conf.py
+++ b/cosinnus/conf.py
@@ -891,6 +891,16 @@ class CosinnusConf(AppConf):
         "^/setup/",
         "^api/auth/",
     ]
+
+    # Forum space label in the v3 main navigation.
+    V3_MENU_SPACES_FORUM_LABEL = _('Forum')
+
+    # Map space label in the v3 main navigation.
+    V3_MENU_SPACES_MAP_LABEL = _('Map')
+
+    # List of help items to be included in the v3 main navigation.
+    # Format: (<label>, <url>, <icon>), e.g.: (_('FAQ'), 'https://wechange.de/cms/help/', 'fa-question-circle'),
+    V3_MENU_HELP_LINKS = []
     
     # whether the regular user signup method is enabled for this portal
     USER_SIGNUP_ENABLED = True

--- a/cosinnus/tests/view_tests/test_navigation_api.py
+++ b/cosinnus/tests/view_tests/test_navigation_api.py
@@ -1,14 +1,17 @@
 from unittest.mock import patch
 from django.contrib.auth import get_user_model
+from django.template.defaultfilters import date
 from django.urls import reverse
-from rest_framework.test import APITestCase
+from rest_framework.test import APITestCase, override_settings
 
+from cosinnus.api_frontend.views.navigation import AlertsView
 from cosinnus.conf import settings
 from cosinnus.models.group import CosinnusPortal
 from cosinnus.models.group_extra import CosinnusSociety
 from cosinnus.models.idea import CosinnusIdea
 from cosinnus.models.membership import MEMBERSHIP_MEMBER
 from cosinnus.models.tagged import LikeObject
+from cosinnus.utils.dates import timestamp_from_datetime
 from cosinnus_notifications.models import NotificationAlert
 
 
@@ -23,7 +26,7 @@ TEST_USER_DATA = {
 }
 
 
-class SpacesTestView(APITestCase):
+class SpacesViewTest(APITestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -64,14 +67,11 @@ class SpacesTestView(APITestCase):
             response.data['groups'],
             {
                 'items': [
-                    {'icon': 'fa-sitemap', 'label': 'Test Group', 'url': 'http://default domain/group/test-group/',
-                     'image': None}
+                    {'icon': 'fa-sitemap', 'label': 'Test Group', 'url': 'http://default domain/group/test-group/', 'image': None}
                 ],
                 'actions': [
-                     {'icon': None, 'label': 'Create new Group', 'url': 'http://default domain/groups/add/',
-                      'image': None},
-                     {'icon': None, 'label': 'Create new Project', 'url': 'http://default domain/projects/add/',
-                      'image': None}
+                     {'icon': None, 'label': 'Create new Group', 'url': 'http://default domain/groups/add/', 'image': None},
+                     {'icon': None, 'label': 'Create new Project', 'url': 'http://default domain/projects/add/', 'image': None}
                  ]
             }
         )
@@ -85,16 +85,17 @@ class SpacesTestView(APITestCase):
             response.data['community'],
             {
                 'items': [
-                    {'icon': 'fa-sitemap', 'label': 'Forum', 'url': 'http://default domain/group/forum/',
-                     'image': None},
-                    {'icon': 'fa-group', 'label': 'Map', 'url': 'http://default domain/map/', 'image': None}
+                    {'icon': 'fa-sitemap', 'label': settings.COSINNUS_V3_MENU_SPACES_FORUM_LABEL,
+                     'url': 'http://default domain/group/forum/', 'image': None},
+                    {'icon': 'fa-group', 'label': settings.COSINNUS_V3_MENU_SPACES_MAP_LABEL,
+                     'url': 'http://default domain/map/', 'image': None}
                 ],
                 'actions': []
             }
         )
 
 
-class BookmarksTestView(APITestCase):
+class BookmarksViewTest(APITestCase):
 
 
     @classmethod
@@ -116,8 +117,7 @@ class BookmarksTestView(APITestCase):
         self.assertListEqual(
             response.data['groups'],
             [
-                {'icon': 'fa-sitemap', 'label': 'Test Group', 'url': 'http://default domain/group/test-group/',
-                 'image': None}
+                {'icon': 'fa-sitemap', 'label': 'Test Group', 'url': 'http://default domain/group/test-group/', 'image': None}
             ]
         )
 
@@ -146,7 +146,7 @@ class BookmarksTestView(APITestCase):
         )
 
 
-class UnreadMessagesTestView(APITestCase):
+class UnreadMessagesViewTest(APITestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -166,7 +166,20 @@ class UnreadMessagesTestView(APITestCase):
         self.assertDictEqual(response.data, {'count': 10})
 
 
-class UnreadAlertsTestView(APITestCase):
+class TestAlertsMixin:
+    def setUp(self):
+        super().setUp()
+        self.group = CosinnusSociety.objects.create(name='Test Group')
+
+    def create_test_alert(self, seen=False):
+        alert = NotificationAlert.objects.create(
+            user=self.test_user, notification_id='note__note_created', portal=self.portal,
+            target_object=self.group, seen=seen, action_user=self.test_user
+        )
+        return alert
+
+
+class UnreadAlertsViewTest(TestAlertsMixin, APITestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -180,14 +193,156 @@ class UnreadAlertsTestView(APITestCase):
         self.assertEqual(response.status_code, 403)
 
     def test_unread_alerts_count(self):
-        group = CosinnusSociety.objects.create(name='Test Group')
-        notification_alert_init_data = {
-            'user': self.test_user, 'target_object':group, 'action_user':self.test_user, 'portal':self.portal
-        }
-        NotificationAlert.objects.create(seen=True, **notification_alert_init_data)
-        NotificationAlert.objects.create(seen=False, **notification_alert_init_data)
-        NotificationAlert.objects.create(seen=False, **notification_alert_init_data)
+        self.create_test_alert(seen=True)
+        self.create_test_alert(seen=False)
         self.client.force_login(self.test_user)
         response = self.client.get(self.api_url)
         self.assertEqual(response.status_code, 200)
-        self.assertDictEqual(response.data, {'count': 2})
+        self.assertDictEqual(response.data, {'count': 1})
+
+
+class AlertsViewTest(TestAlertsMixin, APITestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.api_url = reverse("cosinnus:frontend-api:api-navigation-alerts")
+        cls.test_user = User.objects.create(**TEST_USER_DATA)
+        cls.portal = CosinnusPortal.get_current()
+
+    def test_login_required(self):
+        response = self.client.get(self.api_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_alerts(self):
+        self.client.force_login(self.test_user)
+        alert = self.create_test_alert()
+        alert_action_datetime = date(alert.last_event_at, 'c')
+        alert_timestamp = timestamp_from_datetime(alert.last_event_at)
+        response = self.client.get(self.api_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(
+            response.data,
+            {
+                'items': [
+                    {
+                        'text': '<b>Test User</b> created the news post <b></b>.', 'id': alert.pk, 'url': None,
+                        'item_icon_or_image_url': None, 'user_icon_or_image_url': '/static/images/jane-doe-small.png',
+                        'group': None, 'group_icon': None, 'action_datetime': alert_action_datetime,
+                        'is_emphasized': True, 'alert_reason': 'You are following this content or its Project or Group',
+                        'sub_items': [], 'is_multi_user_alert': False, 'is_bundle_alert': False
+                     }
+                ],
+                'has_more': False,
+                'offset_timestamp': alert_timestamp,
+                'newest_timestamp': alert_timestamp,
+            }
+        )
+
+    def test_alerts_offset_pagination(self):
+        AlertsView.page_size = 1
+        alert1 = self.create_test_alert()
+        alert1_timestamp = timestamp_from_datetime(alert1.last_event_at)
+        alert2 = self.create_test_alert()
+        alert2_timestamp = timestamp_from_datetime(alert2.last_event_at)
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.api_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['items']), 1)
+        self.assertEqual(response.data['items'][0]['id'], alert2.pk)
+        self.assertTrue(response.data['has_more'])
+        self.assertEqual(response.data['offset_timestamp'], alert2_timestamp)
+
+        # query next alerts
+        offset_param = f'?offset_timestamp={alert2_timestamp}'
+        response = self.client.get(self.api_url + offset_param)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['items']), 1)
+        self.assertEqual(response.data['items'][0]['id'], alert1.pk)
+        self.assertFalse(response.data['has_more'])
+        self.assertEqual(response.data['offset_timestamp'], alert1_timestamp)
+
+    def test_alerts_newer_then_param(self):
+        AlertsView.page_size = 1
+        alert1 = self.create_test_alert()
+        alert1_timestamp = timestamp_from_datetime(alert1.last_event_at)
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.api_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['items']), 1)
+        self.assertEqual(response.data['items'][0]['id'], alert1.pk)
+        self.assertEqual(response.data['newest_timestamp'], alert1_timestamp)
+
+        # create newer alert
+        alert2 = self.create_test_alert()
+        alert2_timestamp = timestamp_from_datetime(alert2.last_event_at)
+        newer_then_param = f'?newer_then_timestamp={alert1_timestamp}'
+        response = self.client.get(self.api_url + newer_then_param)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.data['items']), 1)
+        self.assertEqual(response.data['items'][0]['id'], alert2.pk)
+        self.assertEqual(response.data['newest_timestamp'], alert2_timestamp)
+
+
+class HelpViewTest(APITestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.api_url = reverse("cosinnus:frontend-api:api-navigation-help")
+        cls.test_user = User.objects.create(**TEST_USER_DATA)
+        cls.portal = CosinnusPortal.get_current()
+
+    @override_settings(COSINNUS_V3_MENU_HELP_LINKS=[('FAQ', 'https://example.com/faq/', 'fa-question-circle')])
+    def test_help(self):
+        response = self.client.get(self.api_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertListEqual(
+            response.data,
+            [{'icon': 'fa-question-circle', 'label': 'FAQ', 'url': 'https://example.com/faq/', 'image': None}]
+        )
+
+
+class ProfileViewTest(APITestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.api_url = reverse("cosinnus:frontend-api:api-navigation-profile")
+        cls.test_user = User.objects.create(**TEST_USER_DATA)
+        cls.portal = CosinnusPortal.get_current()
+
+    def test_login_required(self):
+        response = self.client.get(self.api_url)
+        self.assertEqual(response.status_code, 403)
+
+    def test_profile(self):
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.api_url)
+        self.assertEqual(response.status_code, 200)
+        expected_language_items = [
+            {'icon': None, 'label': language, 'url': f'http://default domain/language/{code}/', 'image': None}
+            for code, language in settings.LANGUAGES
+        ]
+        self.assertListEqual(
+            response.data,
+            [
+                {'icon': 'fa-circle-user', 'label': 'My Profile', 'url': 'http://default domain/profile/', 'image': None},
+                {'icon': 'fa-pen', 'label': 'Set up my Profile', 'url': 'http://default domain/setup/profile/', 'image': None},
+                {'icon': 'fa-gear', 'label': 'Edit my Profile', 'url': 'http://default domain/profile/edit/', 'image': None},
+                {'icon': 'fa-envelope', 'label': 'Notification Preferences', 'url': 'http://default domain/profile/notifications/', 'image': None},
+                {'icon': 'fa-language', 'label': 'Change Language', 'url': None, 'image': None, 'sub_items': expected_language_items},
+                {'icon': 'fa-right-from-bracket', 'label': 'Logout', 'url': 'http://default domain/logout/', 'image': None},
+            ]
+        )
+
+    def test_profile_admin(self):
+        self.test_user.is_superuser = True
+        self.test_user.save()
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.api_url)
+        self.assertEqual(
+            response.data[5],
+            {'icon': 'fa-screwdriver-wrench', 'label': 'Administration', 'url': 'http://default domain/administration/', 'image': None}
+        )
+

--- a/cosinnus/urls_api_frontend.py
+++ b/cosinnus/urls_api_frontend.py
@@ -5,7 +5,8 @@ from django.conf.urls import url
 
 from cosinnus.api_frontend.views.user import LoginView, SignupView, UserProfileView,\
     LogoutView
-from cosinnus.api_frontend.views.navigation import BookmarksView, SpacesView, UnreadMessagesView, UnreadAlertsView
+from cosinnus.api_frontend.views.navigation import BookmarksView, SpacesView, UnreadMessagesView, UnreadAlertsView, \
+    AlertsView, HelpView, ProfileView
 from cosinnus.core.registries.group_models import group_model_registry
 from cosinnus.api_frontend.views.portal import PortalTopicsView,\
     PortalManagedTagsView, PortalTagsView, PortalUserprofileDynamicFieldsView,\
@@ -37,4 +38,7 @@ urlpatterns += [
     url(r'^api/v3/navigation/bookmarks/$', BookmarksView.as_view(), name='api-navigation-bookmarks'),
     url(r'^api/v3/navigation/unread_messages/$', UnreadMessagesView.as_view(), name='api-navigation-unread-messages'),
     url(r'^api/v3/navigation/unread_alerts/$', UnreadAlertsView.as_view(), name='api-navigation-unread-alerts'),
+    url(r'^api/v3/navigation/alerts/$', AlertsView.as_view(), name='api-navigation-alerts'),
+    url(r'^api/v3/navigation/help/$', HelpView.as_view(), name='api-navigation-help'),
+    url(r'^api/v3/navigation/profile/$', ProfileView.as_view(), name='api-navigation-profile'),
 ]


### PR DESCRIPTION
Followup PR for: https://github.com/wechange-eg/cosinnus-core/pull/324

- Fixup: Read forum and map spaces label from conf to make if adjustable for portals
- Alerts endpoint is copying the functionality of the AlertsRetriaval Dashboard WidgetView
- Help endpoint reads the menu items from a conf setting
- Profile endpoint mirrors the logic in the `v2/navbar/narbar.html` template.
- Make menu item labels translatable