### PR TITLE
Navigation api improvements

### DIFF
--- a/cosinnus/api_frontend/views/navigation.py
+++ b/cosinnus/api_frontend/views/navigation.py
@@ -35,7 +35,8 @@ class SpacesView(MyGroupsClusteredMixin, APIView):
     - Projects and Groups: users projects and groups
     - Community: Forum and Map
     - Conferences: users conferences
-    Each menu item consists of a label (HTML), url, icon (Font Awesome class, optional) and image url (optional).
+    Each menu item consists of a label (Markdown), url, icon (Font Awesome class, optional), image url (optional) and
+    badge (optional).
     """
 
     permission_classes = (IsAuthenticated,)
@@ -203,7 +204,8 @@ class BookmarksView(APIView):
     """
     An endpoint that provides the user bookmarks for the main navigation.
     Returns menu items for liked groups and projects, liked users and liked content (e.g. ideas).
-    Each menu item consists of a label (HTML), url, icon (Font Awesome class, optional) and image url (optional).
+    Each menu item consists of a label (Markdown), url, icon (Font Awesome class, optional), image url (optional) and
+    badge (optional).
     """
 
     permission_classes = (IsAuthenticated,)
@@ -554,7 +556,8 @@ class AlertsView(APIView):
 class HelpView(APIView):
     """
     An endpoint that returns a list of help menu items for the main navigation.
-    Each menu item consists of a label (HTML), url, icon (Font Awesome class, optional) and image url (optional).
+    Each menu item consists of a label (Markdown), url, icon (Font Awesome class, optional), image url (optional) and
+    badge (optional).
     """
 
     renderer_classes = (CosinnusAPIFrontendJSONResponseRenderer, BrowsableAPIRenderer,)
@@ -600,7 +603,8 @@ class ProfileView(APIView):
     An endpoint that provides user profile menu items for the main navigation.
     Returns a list of menu items for user profile and notification settings, contribution, administration, logout and a
     language switcher item. The language switcher item contains a list of menu items for the available languages.
-    Each menu item consists of a label (HTML), url, icon (Font Awesome class, optional) and image url (optional).
+    Each menu item consists of a label (Markdown), url, icon (Font Awesome class, optional), image url (optional) and
+    badge (optional).
     """
 
     permission_classes = (IsAuthenticated,)
@@ -680,10 +684,14 @@ class ProfileView(APIView):
             profile_menu.append(language_item)
 
         # payments
-        # TODO: consider my_contribution_badge
         if settings.COSINNUS_PAYMENTS_ENABLED or settings.COSINNUS_PAYMENTS_ENABLED_ADMIN_ONLY \
                 and request.user.is_superuser:
-            payments_item = MenuItem(_('Your Contribution'), reverse('wechange-payments:overview'), 'fa-hand-holding-hart')
+            from wechange_payments.models import Subscription
+            current_subscription = Subscription.get_current_for_user(request.user)
+            contribution = int(current_subscription.amount) if current_subscription else 0
+            contribution_badge = f'{contribution} €'
+            payments_item = MenuItem(_('Your Contribution'), reverse('wechange-payments:overview'),
+                                     'fa-hand-holding-hart', badge=contribution_badge)
             profile_menu.append(payments_item)
 
         # administration

--- a/cosinnus/api_frontend/views/navigation.py
+++ b/cosinnus/api_frontend/views/navigation.py
@@ -354,10 +354,9 @@ class AlertsView(APIView):
     Each sub alert contains text (label), url and icon_or_image_url elements.
     The response list is paginated by 10 items. For pagination the "offset_timestamp" parameter should be used.
     To receive new alerts the "newer_than_timestamp" should be used.
+
+    Additionally, the retrieved alerts can be marked as read/seen using the "mark_as_read=true" query parameter.
     """
-    # TODO: consider caching.
-    # TODO: discuss pagination, newer_than_timestamp, offset_timestamp.
-    # TODO: discuss limiting the fields to data needed by the frontend.
 
     permission_classes = (IsAuthenticated,)
     renderer_classes = (CosinnusAPIFrontendJSONResponseRenderer, BrowsableAPIRenderer,)
@@ -372,6 +371,7 @@ class AlertsView(APIView):
     page_size = 10
     newer_than_timestamp = None
     offset_timestamp = None
+    mark_as_read = False
 
     @swagger_auto_schema(
         manual_parameters=[
@@ -383,6 +383,10 @@ class AlertsView(APIView):
             openapi.Parameter(
                 'offset_timestamp', openapi.IN_QUERY, required=False,
                 description='Return alerts older then this timestamp. Used for pagination.', type=openapi.FORMAT_FLOAT
+            ),
+            openapi.Parameter(
+                'mark_as_read', openapi.IN_QUERY, required=False,
+                description='Mark unread alerts as read.', type=openapi.TYPE_BOOLEAN
             ),
         ],
         responses={'200': openapi.Response(
@@ -486,6 +490,12 @@ class AlertsView(APIView):
         queryset = queryset[:self.page_size]
         alerts = list(queryset)
 
+        # mark as read
+        if self.mark_as_read:
+            for alert in alerts:
+                alert.seen = True
+            NotificationAlert.objects.bulk_update(alerts, ['seen'])
+
         # alert items
         user_cache = self.get_user_cache(alerts)
         items = [
@@ -522,6 +532,7 @@ class AlertsView(APIView):
                 self.offset_timestamp= float(self.offset_timestamp)
             except Exception:
                 raise ValidationError({'offset_timestamp': 'Float timestamp expected'})
+        self.mark_as_read = request.query_params.get('mark_as_read') == 'true'
 
     def get_queryset(self):
         alerts_qs = NotificationAlert.objects.filter(portal=CosinnusPortal.get_current(), user=self.request.user)

--- a/cosinnus/models/user_dashboard.py
+++ b/cosinnus/models/user_dashboard.py
@@ -105,11 +105,11 @@ class DashboardItem(dict):
 
 class MenuItem(dict):
     """
-    Dictionary used as a representation and API serializer of menu links consisting of a label, url, icon (optional)
-    and image-url (optional). Used in the v3 navigation API.
+    Dictionary used as a representation and API serializer of menu links consisting of a label, url, icon (optional),
+    image-url (optional) and badge (optional). Used in the v3 navigation API.
     """
 
-    def __init__(self, label, url, icon=None, image=None):
+    def __init__(self, label, url, icon=None, image=None, badge=None):
         domain = get_domain_for_portal(CosinnusPortal.get_current())
         if url and url[0] == '/':
             url = domain + url
@@ -119,3 +119,4 @@ class MenuItem(dict):
         if image and image[0] == '/':
             image = domain + image
         self['image'] = image
+        self['badge'] = badge

--- a/cosinnus/tests/utils.py
+++ b/cosinnus/tests/utils.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-
-from django.utils.unittest import skipIf, skipUnless
+import sys
+from importlib import reload, import_module
+from django.urls import clear_url_caches
+from unittest import skipIf, skipUnless
 
 from cosinnus.conf import settings
 
@@ -44,3 +46,17 @@ def skipUnlessCustomUserProfileSerializer(test_func):
     """
     return skipUnless(_is_custom_userprofileserializer(),
         'No custom cosinnus user profile serializer model in use')(test_func)
+
+
+def reload_urlconf(urlconf=None):
+    """
+    Reload the url config. Useful when testing with override_settings that enables new urls.
+    Source: https://stackoverflow.com/a/46034755
+    """
+    clear_url_caches()
+    if urlconf is None:
+        urlconf = settings.ROOT_URLCONF
+    if urlconf in sys.modules:
+        reload(sys.modules[urlconf])
+    else:
+        import_module(urlconf)

--- a/cosinnus/tests/view_tests/test_navigation_api.py
+++ b/cosinnus/tests/view_tests/test_navigation_api.py
@@ -200,6 +200,20 @@ class UnreadAlertsViewTest(TestAlertsMixin, APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(response.data, {'count': 1})
 
+    def test_mark_as_read(self):
+        self.create_test_alert(seen=False)
+        self.client.force_login(self.test_user)
+        response = self.client.get(self.api_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(response.data, {'count': 1})
+
+        mark_as_readr_url = reverse("cosinnus:frontend-api:api-navigation-alerts") + '?mark_as_read=true'
+        response = self.client.get(mark_as_readr_url)
+        self.assertEqual(response.status_code, 200)
+        response = self.client.get(self.api_url)
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(response.data, {'count': 0})
+
 
 class AlertsViewTest(TestAlertsMixin, APITestCase):
 
@@ -282,6 +296,14 @@ class AlertsViewTest(TestAlertsMixin, APITestCase):
         self.assertEqual(len(response.data['items']), 1)
         self.assertEqual(response.data['items'][0]['id'], alert2.pk)
         self.assertEqual(response.data['newest_timestamp'], alert2_timestamp)
+
+    def test_alerts_mark_as_read(self):
+        self.client.force_login(self.test_user)
+        alert = self.create_test_alert()
+        response = self.client.get(self.api_url)
+        self.assertTrue(response.data['items'][0]['is_emphasized'])
+        response = self.client.get(self.api_url + '?mark_as_read=true')
+        self.assertFalse(response.data['items'][0]['is_emphasized'])
 
 
 class HelpViewTest(APITestCase):


### PR DESCRIPTION
Contains:

- "mark_as_read" parameter for alerts
- Badge element for menu-item and contribution badge
- Use Markdown instead of HTML for labels (comments)

Notes:

- Added a test utility to reload the url config when testing with changed settings
- Switched to using menu-items in tests instead of plain dicts