### PR TITLE
Dynamic conference participant information - Fixups

### DIFF
--- a/cosinnus/static/less/misc.less
+++ b/cosinnus/static/less/misc.less
@@ -485,3 +485,7 @@ ol.blank-list, ol.blank-list li {
     text-decoration-style: dotted;
     cursor: help;
 }
+
+.background-light-fadeout {
+    background-color:fadeout(@app-neutral-color-light, 50);
+}

--- a/cosinnus/templates/cosinnus/conference/motivation_answer_inline.html
+++ b/cosinnus/templates/cosinnus/conference/motivation_answer_inline.html
@@ -1,5 +1,7 @@
 {% load i18n widget_tweaks %}
 
-<em>{{ inlineform.question.value|linebreaks }}</em>
+<div class="small-padding background-light-fadeout transparent-p">
+    <em>{{ inlineform.question.value|linebreaks }}</em>
+</div>
 {% include 'cosinnus/fields/default_field.html' with field=inlineform.answer label=None large_field=True %}
 {{ inlineform.question }}

--- a/cosinnus_conference/views.py
+++ b/cosinnus_conference/views.py
@@ -1178,7 +1178,7 @@ class ConferenceApplicantsDetailsDownloadView(SamePortalGroupMixin,
         return result
 
     def get_motivation_question_strings(self):
-        return ['{}: {}'.format(_('Motivation'), question.get('question')) for question in self.management.motivation_questions]
+        return [question.get('question', '') for question in self.management.motivation_questions]
 
     def get_motivation_answers(self, application):
         answers = []


### PR DESCRIPTION
Minor fixups:
- Use lilght brackground for question in application form
  -  Simple/hacky fix, probably needs discussion
- Remove "Motivation:" prefix from motivation columns in application download