### PR TITLE
Conference link for clipboard fixup

### DIFF
--- a/cosinnus_conference/api/views.py
+++ b/cosinnus_conference/api/views.py
@@ -10,7 +10,7 @@ from cosinnus_event.models import ConferenceEvent, ConferenceEventAttendanceTrac
 
 # FIXME: Make this pagination class default in REST_FRAMEWORK setting
 from rest_framework.decorators import action
-from cosinnus.utils.permissions import check_user_superuser, check_object_write_access
+from cosinnus.utils.permissions import check_user_superuser, check_object_write_access, check_object_read_access
 from cosinnus.models.group_extra import CosinnusConference, CosinnusGroup
 from cosinnus.api.views.mixins import CosinnusFilterQuerySetMixin,\
     PublicCosinnusGroupFilterMixin, CosinnusPaginateMixin
@@ -128,6 +128,10 @@ class ConferenceViewSet(RequireGroupReadMixin, BaseConferenceViewSet):
             obj = object_class.objects.filter(id=object_id).first()
         if not obj:
             return Response(status=404)
+
+        # Check access permissions
+        if not check_object_read_access(obj, request.user):
+            return Response(status=403)
 
         bbb_room = getattr(obj.media_tag, 'bbb_room', None)
         if bbb_room:

--- a/cosinnus_event/templates/cosinnus_event/single_event_detailed.html
+++ b/cosinnus_event/templates/cosinnus_event/single_event_detailed.html
@@ -495,7 +495,9 @@
                 </ul>
             </button>
 
-            {% include "cosinnus/conference/conference_invitation_text_buttons.html" with object_type="event" %}
+            {% if SETTINGS.COSINNUS_BBB_ENABLE_GROUP_AND_EVENT_BBB_ROOMS and event.video_conference_type == 1 %}
+                {% include "cosinnus/conference/conference_invitation_text_buttons.html" with object_type="event" %}
+            {% endif %}
 
             <div class="clearfix"></div>
 	    </div>


### PR DESCRIPTION
Fixups for https://github.com/wechange-eg/cosinnus-core/pull/360:

- Show invitation text buttons for event conferences only if BBB is used
- Check access permissions in the invitation endpoint of the conference API