### PR TITLE
Fix membership cache inconsistancy

### DIFF
--- a/cosinnus/models/group.py
+++ b/cosinnus/models/group.py
@@ -1080,9 +1080,7 @@ class CosinnusBaseGroup(HumanizedEventTimeMixin, TranslateableFieldsModelMixin, 
         membership = CosinnusGroupMembership.objects.create(user=user,
             group=group, status=MEMBERSHIP_ADMIN)
         # clear cache and manually refill because race conditions can make the group memberships be cached as empty
-        membership._clear_cache() 
-        group.members # this refills the group's member cache immediately
-        group.admins # this refills the group's member cache immediately
+        membership._refresh_cache()
         group.update_index()
         return group
     

--- a/cosinnus/models/membership.py
+++ b/cosinnus/models/membership.py
@@ -281,9 +281,22 @@ class MembersManagerMixin(object):
         return self.membership_class.objects.get_members(self.pk)
 
     @property
+    def members_uncached(self):
+        """ Returns a list of user ids that are members of this group. The membership if fetched from the db. """
+        query = self.membership_class.objects.filter(group_id=self.pk).filter_membership_status(MEMBER_STATUS)
+        return list(query.values_list('user_id', flat=True).all())
+
+    @property
     def actual_members(self):
         """ Returns a QS of users that are members of this group (admins and members) and are actually active and visible on the site """
         qs = get_user_model().objects.filter(id__in=self.members)
+        qs = filter_active_users(qs)
+        return qs
+
+    @property
+    def actual_members_uncached(self):
+        """ Returns a QS of active users that are members of this group. The membership is fetched from the db. """
+        qs = get_user_model().objects.filter(id__in=self.members_uncached)
         qs = filter_active_users(qs)
         return qs
 

--- a/cosinnus/search_indexes.py
+++ b/cosinnus/search_indexes.py
@@ -134,7 +134,11 @@ class CosinnusGroupIndexMixin(LocalCachedIndexMixin, DocumentBoostMixin, StoredD
     
     def prepare_group_members(self, obj):
         if not hasattr(obj, '_group_members'):
-            obj._group_members = obj.members
+            # during threaded indexing we should not use cached properties and should not write to the cache.
+            if getattr(settings, 'COSINNUS_ELASTIC_BACKEND_RUN_THREADED', True):
+                obj._group_members = obj.members_uncached
+            else:
+                obj._group_members = obj.members
         return obj._group_members
     
     def prepare_member_count(self, obj):
@@ -181,7 +185,11 @@ class CosinnusGroupIndexMixin(LocalCachedIndexMixin, DocumentBoostMixin, StoredD
             return qs
         
         mean, stddev = self.get_mean_and_stddev(qs_func, 'memberships')
-        group_member_count = group.actual_members.count()
+        # during threaded indexing we should not use cached properties and should not write to the cache.
+        if getattr(settings, 'COSINNUS_ELASTIC_BACKEND_RUN_THREADED', True):
+            group_member_count = group.actual_members_uncached.count()
+        else:
+            group_member_count = group.actual_members.count()
         members_rank = normalize_within_stddev(group_member_count, mean, stddev, stddev_factor=1.0)
         
         age_timedelta = now() - obj.created

--- a/cosinnus/views/group.py
+++ b/cosinnus/views/group.py
@@ -359,9 +359,8 @@ class GroupCreateView(CosinnusGroupFormMixin, RequireVerifiedUserMixin, Attachab
             group=self.object, status=MEMBERSHIP_ADMIN)
         
         # clear cache and manually refill because race conditions can make the group memberships be cached as empty
-        membership._clear_cache() 
-        self.object.members # this refills the group's member cache immediately
-        self.object.admins # this refills the group's member cache immediately
+        membership._refresh_cache()
+        membership.group.update_index()
 
         
         # send group creation signal, 

--- a/cosinnus_organization/views/organization.py
+++ b/cosinnus_organization/views/organization.py
@@ -99,9 +99,8 @@ class OrganizationCreateView(RequireLoggedInMixin, CosinnusOrganizationFormMixin
                                                                    group=self.object, status=MEMBERSHIP_ADMIN)
 
         # clear cache and manually refill because race conditions can make the group memberships be cached as empty
-        membership._clear_cache()
-        self.object.members  # this refills the group's member cache immediately
-        self.object.admins  # this refills the group's member cache immediately
+        membership._refresh_cache()
+        membership.group.update_index()
 
         cosinnus_notifications.organization_created.send(sender=self, user=self.request.user, obj=self.object,
                                                          audience=[])


### PR DESCRIPTION
Issue: https://git.wechange.de/code/portals/boell/-/issues/38 (and other)

Contains:
- Improvement to the clear-cache functionality
- Use extra membership functions that do not use the cache for memberships during search indexing