### PR TITLE
Fixup tags search link

### DIFF
--- a/cosinnus/templates/cosinnus/media_tags_readonly.html
+++ b/cosinnus/templates/cosinnus/media_tags_readonly.html
@@ -34,7 +34,7 @@
 				                        <li class="w100 font11px no-vertical-padding no-horizontal-padding">
 				                            <i class="fa fa-fw fa-tags"></i>
 					                        {% for tag in tags %}
-					                            <a href="{% url 'cosinnus:map' %}?q={{ tag }}">{{ tag }}</a>
+					                            <a href="{% url 'cosinnus:search' %}?q={{ tag }}">{{ tag }}</a>
 					                        {% endfor %}
 				                       </li>
 				                    </ol>

--- a/cosinnus/templates/cosinnus/v2/dashboard/timeline_item_base.html
+++ b/cosinnus/templates/cosinnus/v2/dashboard/timeline_item_base.html
@@ -156,7 +156,7 @@
 								<span>
 									<i class="fas fa-fw fa-tag"></i>
 									{% for tag in tags %}
-										{{ tag }}{% if not forloop.last %}, {% endif %}
+                                        <a href="{% url 'cosinnus:search' %}?q={{ tag }}">{{ tag }}</a>{% if not forloop.last %}, {% endif %}
 									{% endfor %}
 								</span>
 							{% endif %}


### PR DESCRIPTION
Issue: https://git.wechange.de/code/portals/wechange/-/issues/1750

Contains: 
- Tags link to search instead of map
- Add links to tags in the dashboard timeline