### PR TITLE
Force index update of user for newly created group

### DIFF
--- a/cosinnus/views/group.py
+++ b/cosinnus/views/group.py
@@ -362,7 +362,11 @@ class GroupCreateView(CosinnusGroupFormMixin, RequireVerifiedUserMixin, Attachab
         membership._refresh_cache()
         membership.group.update_index()
 
-        
+        # During the initial indexing of the admins property of the user the newly created group is not always included
+        # in the threaded query. Forcing a reindex to make sure the user is listed as the admin of the created group.
+        if hasattr(self.request.user, 'cosinnus_profile'):
+            self.request.user.cosinnus_profile.update_index()
+
         # send group creation signal, 
         # from here, because in group.save() we don't know the group's creator
         # the audience is empty because this is a moderator-only notification


### PR DESCRIPTION
Issue: https://git.wechange.de/code/portals/boell/-/issues/38

- user index contains the admin information for the group
- during the initial indexing the group is sometimes missing in the admin list