### PR TITLE
User matching Rocket.Chat integration fixup

### DIFF
--- a/cosinnus/models/profile.py
+++ b/cosinnus/models/profile.py
@@ -905,8 +905,10 @@ class UserMatchObject(models.Model):
                 )
                 try:
                     rocket = RocketChatConnection()
-                    internal_room_id = rocket.create_private_room(room_name, self.from_user,
-                          additional_admin_users=[self.to_user], room_topic=room_topic, greeting_message=greeting_message)
+                    internal_room_id = rocket.create_private_room(
+                        room_name, self.from_user, member_users=[self.from_user, self.to_user],
+                        additional_admin_users=[self.to_user], room_topic=room_topic, greeting_message=greeting_message
+                    )
                 except RocketChatDownException:
                     logger.error(RocketChatConnection.ROCKET_CHAT_DOWN_ERROR)
                     internal_room_id = None

--- a/cosinnus/views/user_match.py
+++ b/cosinnus/views/user_match.py
@@ -168,21 +168,6 @@ def check_for_user_match(from_user, to_user):
         match_case_from = UserMatchObject.objects.get(from_user=from_user, to_user=to_user, type=UserMatchObject.LIKE)
         match_case_to = UserMatchObject.objects.get(from_user=to_user, to_user=from_user, type=UserMatchObject.LIKE)
         
-        # Create email notifications
-        cosinnus_notifications.user_match_established.send(
-                    sender=from_user,
-                    obj=match_case_from,
-                    user=from_user,
-                    audience=[to_user,]
-                )
-
-        cosinnus_notifications.user_match_established.send(
-                    sender=to_user,
-                    obj=match_case_to,
-                    user=to_user,
-                    audience=[from_user,]
-                )
-        
         # open rocketchat
         if settings.COSINNUS_ROCKET_ENABLED:
             room_url = match_case_from.get_rocketchat_room_url()
@@ -190,6 +175,22 @@ def check_for_user_match(from_user, to_user):
                 match_case_to.rocket_chat_room_id = match_case_from.rocket_chat_room_id
                 match_case_to.rocket_chat_room_name = match_case_from.rocket_chat_room_name
                 match_case_to.save()
+
+                # Create notifications
+                cosinnus_notifications.user_match_established.send(
+                    sender=from_user,
+                    obj=match_case_from,
+                    user=from_user,
+                    audience=[to_user,]
+                )
+
+                cosinnus_notifications.user_match_established.send(
+                    sender=to_user,
+                    obj=match_case_to,
+                    user=to_user,
+                    audience=[from_user,]
+                )
+
         else:
             logger.info('RocketChat is not enabled on this portal!')
     except UserMatchObject.DoesNotExist:


### PR DESCRIPTION
Issue: https://git.wechange.de/code/portals/ifa/-/issues/52

Contains:
- Sets member_users correctly when creating the private room for the match
- Generate match notification after the RocketChat room is created