### PR TITLE
Refresh membership cache when updating users group membership

### DIFF
--- a/cosinnus/views/group.py
+++ b/cosinnus/views/group.py
@@ -1332,6 +1332,7 @@ class GroupUserUpdateView(AjaxableFormMixin, RequireAdminMixin,
                 cosinnus_notifications.user_group_admin_demoted.send(sender=self, obj=self.object.group, user=self.request.user, audience=[user])
             ret = super(GroupUserUpdateView, self).form_valid(form)
             # update index for the group
+            self.object._refresh_cache()
             self.object.group.update_index()
             return ret
         return HttpResponseRedirect(self.get_success_url())


### PR DESCRIPTION
Due to a cache issue the members list sometimes did not include a user after accepting the membership.