### PR TITLE
Fixup for tos_accepted field usage

### DIFF
--- a/cosinnus_conference/views.py
+++ b/cosinnus_conference/views.py
@@ -353,8 +353,7 @@ class WorkshopParticipantsDownloadView(SamePortalGroupMixin, RequireWriteMixin,
                 workshop_username = profile.readable_workshop_user_name
                 email = member.email
                 has_logged_in, logged_in_date = self.get_last_login(member)
-                tos_accepted = 1 if profile.settings.get(
-                    'tos_accepted', False) else 0
+                tos_accepted = 1 if profile.tos_accepted else 0
                 row = [workshop_username, email, has_logged_in,
                        logged_in_date, tos_accepted]
                 rows.append(row)

--- a/cosinnus_notifications/digest.py
+++ b/cosinnus_notifications/digest.py
@@ -123,7 +123,7 @@ def send_digest_for_current_portal(digest_setting, debug_run_for_user=None, debu
         cur_language = translation.get_language()
         try:
             # only active users that have logged in before accepted the TOS get notifications
-            if not user.is_active or not user.last_login or not cosinnus_setting(user, 'tos_accepted'):
+            if not user.is_active or not user.last_login or not user.cosinnus_profile.tos_accepted:
                 continue
             
             # switch language to user's preference language so all i18n and date formats are in their language

--- a/cosinnus_notifications/notifications.py
+++ b/cosinnus_notifications/notifications.py
@@ -490,8 +490,8 @@ class NotificationsThread(Thread):
             return False
         if not user.last_login:
             return False
-        if not cosinnus_setting(user, 'tos_accepted'):
-            return False
+        if not user.cosinnus_profile.tos_accepted:
+                return False
         
         # user cannot be object's creator unless explicitly specified
         if hasattr(obj, 'creator'):
@@ -572,7 +572,7 @@ class NotificationsThread(Thread):
             return False
         if not user.last_login:
             return False
-        if not cosinnus_setting(user, 'tos_accepted'):
+        if not user.cosinnus_profile.tos_accepted:
             return False
         
         """


### PR DESCRIPTION
Missed some places where "tos_accepted" is still read from the profile settings.