### PR TITLE
Fix map attribution position

### DIFF
--- a/cosinnus/static/less/extra_designs/white_design.less
+++ b/cosinnus/static/less/extra_designs/white_design.less
@@ -346,12 +346,3 @@ p.navi-explanation {
         width: 100%
     }
 }
-
-.map-fullscreen, .map-embed {
-    .leaflet-bottom {
-        .leaflet-control-attribution {
-            left: unset;
-            right: 0;
-        }
-    }
-}

--- a/cosinnus/static/less/map.less
+++ b/cosinnus/static/less/map.less
@@ -885,21 +885,6 @@
     height: 100%;
 }
 
-
-.map-fullscreen, .map-embed {
-    
-    .leaflet-bottom {
-        position: static;
-
-        .leaflet-control-attribution {
-            position: absolute;
-            left: 0;
-            bottom: 0;
-        }
-    }
-    
-}
-
 /** Everything below here in .map-root is old-style! */
 .map-root {
     


### PR DESCRIPTION
Keep the attribution in the right corner to avoid being hidden by the footer.

Just deleting customization as this is default.