### PR TITLE
RocketChat user update improvements

### DIFF
--- a/cosinnus_message/rocket_chat.py
+++ b/cosinnus_message/rocket_chat.py
@@ -287,20 +287,18 @@ class RocketChatConnection:
                 'User %i/%i. Success: %s \t %s' % (i, count, str(result), user.email),
             )
 
-    def _get_rocket_users_list(self, filter_query):
+    def _get_rocket_users_list(self):
         """
         Get complete Rocket.Chat user list.
-        @param filter_query: query passed to the users_list api call (See https://developer.rocket.chat/reference/api/rest-api#query-parameters)
         @return:
-            - A list of rocketchat user respones if users were found for the query.
-            - An empty list of no users were found for the query.
-            - `None` if an error retrieving the users occured.
+            - A list of all rocketchat users
+            - `None` if an error retrieving the users occurred.
         """
         rocket_users = []
         count = 100
         offset = 0
         while True:
-            response = self.rocket.users_list(count=count, offset=offset, query=filter_query).json()
+            response = self.rocket.users_list(count=count, offset=offset).json()
             if not response.get('success'):
                 self.stderr.write(':_get_rocket_users_list:' + str(response), response)
                 # setting the users list to None to avoid working with incomplete user lists
@@ -319,7 +317,7 @@ class RocketChatConnection:
         :return:
         """
         # Get existing rocket users
-        rocket_users_list = self._get_rocket_users_list(filter_query='')
+        rocket_users_list = self._get_rocket_users_list()
         if rocket_users_list is None:
             # An error occurred fetching the user list.
             return
@@ -472,8 +470,7 @@ class RocketChatConnection:
         username = profile.get_new_rocket_username()
 
         # get existing rocket users matching the username.
-        filter_query = json.dumps({'username': {'$regex': username}})
-        rocket_users = self._get_rocket_users_list(filter_query=filter_query)
+        rocket_users = self._get_rocket_users_list()
         if rocket_users is None:
             # An error occurred fetching the user list.
             return

--- a/cosinnus_message/rocket_chat.py
+++ b/cosinnus_message/rocket_chat.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import mimetypes
 import os
@@ -466,7 +465,7 @@ class RocketChatConnection:
             return self.users_create(user, request)
 
     def has_username_changed(self, profile, rocket_user_name):
-        """ Check it username needs to be updated in RocketChat. """
+        """Check it username needs to be updated in RocketChat."""
         username = profile.get_new_rocket_username()
         username_match = re.match(rf'^{username}\d*$', rocket_user_name)
         return username_match is None
@@ -730,9 +729,9 @@ class RocketChatConnection:
         # Update name, email address, password, verified status if they have changed
         profile = user.cosinnus_profile
         rocket_email = user_data.get('emails', [{}])[0].get('address', None)
-        #rocket_mail_verified = user_data.get('emails', [{}])[0].get('verified', None)
+        # rocket_mail_verified = user_data.get('emails', [{}])[0].get('verified', None)
         rocket_username = user_data.get('username')
-        username_changed = rocket_username is None or self.has_username_changed(profile,  rocket_username)
+        username_changed = rocket_username is None or self.has_username_changed(profile, rocket_username)
         if username_changed:
             rocket_username = self._get_unique_username(profile)
             if not rocket_username:
@@ -749,14 +748,18 @@ class RocketChatConnection:
             }
             # Update email only if it has changed to avoid rate limiting by the RocketChat server.
             if email_changed:
-                data.update({
-                    "email": profile.rocket_user_email,
-                })
+                data.update(
+                    {
+                        'email': profile.rocket_user_email,
+                    }
+                )
             # Update active only if it has changed
             if active_changed:
-                data.update({
-                    "active": user.is_active,
-                })
+                data.update(
+                    {
+                        'active': user.is_active,
+                    }
+                )
             # updating the password invalidates existing user sessions, so use it only
             # when actually needed
             if update_password:

--- a/cosinnus_message/rocket_chat.py
+++ b/cosinnus_message/rocket_chat.py
@@ -467,7 +467,7 @@ class RocketChatConnection:
     def has_username_changed(self, profile, rocket_user_name):
         """Check it username needs to be updated in RocketChat."""
         username = profile.get_new_rocket_username()
-        username_match = re.match(rf'^{username}-?\d*$', rocket_user_name)
+        username_match = re.match(rf'^{username}(-\d+)?$', rocket_user_name)
         return username_match is None
 
     def _get_unique_username(self, profile):

--- a/cosinnus_message/rocket_chat.py
+++ b/cosinnus_message/rocket_chat.py
@@ -467,7 +467,7 @@ class RocketChatConnection:
     def has_username_changed(self, profile, rocket_user_name):
         """Check it username needs to be updated in RocketChat."""
         username = profile.get_new_rocket_username()
-        username_match = re.match(rf'^{username}\d*$', rocket_user_name)
+        username_match = re.match(rf'^{username}-?\d*$', rocket_user_name)
         return username_match is None
 
     def _get_unique_username(self, profile):
@@ -520,6 +520,7 @@ class RocketChatConnection:
         rocket_user_password = user.password or get_random_string(length=16)
         rocket_username = self._get_unique_username(profile)
         if not rocket_username:
+            # A RocketChat error occurred when fetching the user list for unique check. Return without creating user.
             return
 
         # make sure a rocketchat user with that username does not exist.
@@ -731,6 +732,7 @@ class RocketChatConnection:
         rocket_email = user_data.get('emails', [{}])[0].get('address', None)
         # rocket_mail_verified = user_data.get('emails', [{}])[0].get('verified', None)
         rocket_username = user_data.get('username')
+        # rocket_username show never be None, the check is just out of caution
         username_changed = rocket_username is None or self.has_username_changed(profile, rocket_username)
         if username_changed:
             rocket_username = self._get_unique_username(profile)

--- a/cosinnus_message/rocket_chat.py
+++ b/cosinnus_message/rocket_chat.py
@@ -728,7 +728,7 @@ class RocketChatConnection:
         rocket_username = self._get_unique_username(profile)
         if not rocket_username:
             return
-        if force_user_update or user_data.get('name') != rocket_username or rocket_email != profile.rocket_user_email:
+        if force_user_update or user_data.get('username') != rocket_username or rocket_email != profile.rocket_user_email:
             data = {
                 'username': rocket_username,
                 'name': profile.get_external_full_name(),


### PR DESCRIPTION
Contains:
- Remove deprecated user-list query parameter
- Update "active" only if changed
- Update username only if changed