### PR TITLE
Filter feed events by groups publicly_visible field

### DIFF
--- a/cosinnus_event/views.py
+++ b/cosinnus_event/views.py
@@ -875,6 +875,7 @@ class GlobalFeed(BaseEventFeed):
 
     def items(self, request):
         qs = Event.get_current_for_portal()
+        qs = qs.filter(group__publicly_visible=True)
         qs = filter_tagged_object_queryset_for_user(qs, AnonymousUser())
         qs = qs.filter(state=Event.STATE_SCHEDULED, from_date__isnull=False, to_date__isnull=False).order_by(
             '-from_date')


### PR DESCRIPTION
Fixes proxy events of non publicly visible conference being included in the feed.