### PR TITLE
Fix redirect after language change in navbar via api

### DIFF
--- a/cosinnus/api/views/portal.py
+++ b/cosinnus/api/views/portal.py
@@ -125,7 +125,7 @@ class HeaderView(APIView):
     """
 
     def get(self, request):
-        context = Context({'request': request})
+        context = Context({'request': request, 'is_api_request': True})
         return Response(
             {
                 'html': cosinnus_menu_v2(context, request=request),

--- a/cosinnus/templates/cosinnus/v2/navbar/navbar.html
+++ b/cosinnus/templates/cosinnus/v2/navbar/navbar.html
@@ -338,7 +338,7 @@
 			<ul class="item-list">
 				{% for code, language in SETTINGS.LANGUAGES %}
 					<li>
-						<a href="{% url 'cosinnus:switch-language' language=code %}?next={{ request.path }}"
+						<a href="{% url 'cosinnus:switch-language' language=code %}{% if not is_api_request %}?next={{ request.path }}{% endif %}"
 								class="list-item {% if request.LANGUAGE_CODE == code %}text-bold{% endif %}" role="button" titledby=".item-text">
 				    		<div class="item-text">
 				    			{{ language }}


### PR DESCRIPTION
Don't redirect to request.path for api calls. The language switch view redirects to Referer or "/" if next ist not defined.