### PR TITLE
#35 Ensures consistent date formats across languages

### DIFF
--- a/cosinnus/api/serializers/base.py
+++ b/cosinnus/api/serializers/base.py
@@ -3,10 +3,10 @@ from __future__ import unicode_literals
 
 from builtins import object
 
-from django.utils.formats import get_format
 from rest_framework.fields import DateField, DateTimeField, TimeField
 
 from cosinnus.utils.dates import datetime_format_js2py
+from cosinnus.utils.lanugages import get_format_safe
 
 __all__ = ('BaseL10NField', 'DateL10nField', 'DateTimeL10nField', 'TimeL10nField')
 
@@ -16,7 +16,7 @@ class BaseL10NField(object):
 
     def to_native(self, value):
         if value is not None and self.format_key is not None:
-            format_string = get_format(self.format_key)
+            format_string = get_format_safe(self.format_key)
             format = datetime_format_js2py(format_string)
             return value.strftime(format)
         return super(BaseL10NField, self).to_native(value)

--- a/cosinnus/forms/widgets.py
+++ b/cosinnus/forms/widgets.py
@@ -6,10 +6,10 @@ import json
 from bootstrap3_datetime.widgets import DateTimePicker
 from django.forms import widgets
 from django.forms.widgets import DateInput, SplitDateTimeWidget, TimeInput
-from django.utils.formats import get_format
 from django.utils.translation import get_language
 
 from cosinnus.utils.dates import datetime_format_js2py
+from cosinnus.utils.lanugages import get_format_safe
 
 
 def _is_number(s):
@@ -25,7 +25,7 @@ class BaseL10NPicker(DateTimePicker):
 
     def render(self, name, value, attrs=None, renderer=None):
         if self.js_format_key is not None and self.options:
-            js_format_string = get_format(self.js_format_key)
+            js_format_string = get_format_safe(self.js_format_key)
             self.options.update(
                 {
                     'format': js_format_string,

--- a/cosinnus/utils/context_processors.py
+++ b/cosinnus/utils/context_processors.py
@@ -8,7 +8,6 @@ from datetime import timedelta
 from django.template.defaultfilters import date
 from django.urls import Resolver404, resolve, reverse
 from django.utils import timezone
-from django.utils.formats import get_format
 from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 
@@ -21,6 +20,7 @@ from cosinnus.models.managed_tags import CosinnusManagedTag
 from cosinnus.models.profile import GlobalBlacklistedEmail
 from cosinnus.trans.exchange import CosinnusExternalResourceTrans
 from cosinnus.trans.group import get_group_trans_by_type
+from cosinnus.utils.lanugages import get_format_safe
 from cosinnus.utils.permissions import check_user_verified
 from cosinnus.utils.user import check_user_has_accepted_portal_tos, get_user_tos_accepted_date
 from cosinnus.utils.version_history import get_version_history_for_user
@@ -118,14 +118,14 @@ def cosinnus(request):
     context = {
         'COSINNUS_BASE_URL': base_url,
         'COSINNUS_CURRENT_APP': current_app_name,
-        'COSINNUS_DATE_FORMAT': get_format('COSINNUS_DATETIMEPICKER_DATE_FORMAT'),
-        'COSINNUS_DATETIME_FORMAT': get_format('COSINNUS_DATETIMEPICKER_DATETIME_FORMAT'),
-        'COSINNUS_TIME_FORMAT': get_format('COSINNUS_DATETIMEPICKER_TIME_FORMAT'),
-        'COSINNUS_DJANGO_DATETIME_FORMAT': get_format('COSINNUS_DJANGO_DATETIME_FORMAT'),
-        'COSINNUS_DJANGO_DATE_FORMAT': get_format('COSINNUS_DJANGO_DATE_FORMAT'),
-        'COSINNUS_DJANGO_DATE_SHORT_FORMAT': get_format('COSINNUS_DJANGO_DATE_SHORT_FORMAT'),
-        'COSINNUS_DJANGO_DATE_SHORT_CLEAR_FORMAT': get_format('COSINNUS_DJANGO_DATE_SHORT_CLEAR_FORMAT'),
-        'COSINNUS_DJANGO_TIME_FORMAT': get_format('COSINNUS_DJANGO_TIME_FORMAT'),
+        'COSINNUS_DATE_FORMAT': get_format_safe('COSINNUS_DATETIMEPICKER_DATE_FORMAT'),
+        'COSINNUS_DATETIME_FORMAT': get_format_safe('COSINNUS_DATETIMEPICKER_DATETIME_FORMAT'),
+        'COSINNUS_TIME_FORMAT': get_format_safe('COSINNUS_DATETIMEPICKER_TIME_FORMAT'),
+        'COSINNUS_DJANGO_DATETIME_FORMAT': get_format_safe('COSINNUS_DJANGO_DATETIME_FORMAT'),
+        'COSINNUS_DJANGO_DATE_FORMAT': get_format_safe('COSINNUS_DJANGO_DATE_FORMAT'),
+        'COSINNUS_DJANGO_DATE_SHORT_FORMAT': get_format_safe('COSINNUS_DJANGO_DATE_SHORT_FORMAT'),
+        'COSINNUS_DJANGO_DATE_SHORT_CLEAR_FORMAT': get_format_safe('COSINNUS_DJANGO_DATE_SHORT_CLEAR_FORMAT'),
+        'COSINNUS_DJANGO_TIME_FORMAT': get_format_safe('COSINNUS_DJANGO_TIME_FORMAT'),
         'COSINNUS_USER': user_json,
         'COSINNUS_UNREAD_MESSAGE_COUNT': unread_count,
         'COSINNUS_STREAM_UNSEEN_COUNT': stream_unseen_count,

--- a/cosinnus/utils/lanugages.py
+++ b/cosinnus/utils/lanugages.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 from builtins import object
 
 from django.core.exceptions import FieldDoesNotExist
+from django.utils.formats import get_format
 from django.utils.translation import get_language
 
 from cosinnus.conf import settings
@@ -47,3 +48,18 @@ class MultiLanguageFieldValidationFormMixin(object):
                 name = self.cleaned_data.get(other_name_field)
                 break
         return name
+
+
+def get_format_safe(format_type, lang=None, use_l10n=None):
+    """Wrapper for django.utils.formats.get_format Django get_format returns the format-type string unchanged,
+    if the format is not defined for the given language. This wrapper uses the sites default language as a fallback
+    when this happens.
+    """
+    format_primary = get_format(format_type, lang=lang, use_l10n=use_l10n)
+
+    # get and return the format for the default-language, if the primary format is invalid,
+    # i.e. matches the given format string
+    if format_primary == format_type:
+        return get_format(format_type, lang=settings.LANGUAGE_CODE, use_l10n=use_l10n)
+
+    return format_primary


### PR DESCRIPTION
wraps
`django.utils.formats.get_format` to fallback to the site's default language, if format definitions are missing for the current language

fixes  https://git.wechange.de/gl/code/portals/weltweitwissen/-/issues/35
