### PR TITLE
#447 Improves BBB recordings access logic

### DIFF
--- a/cosinnus/models/bbb_room.py
+++ b/cosinnus/models/bbb_room.py
@@ -366,6 +366,11 @@ class BBBRoom(models.Model):
         guest_token = self.get_guest_token()
         create_params = self.__class__.add_guest_link_moderator_only_message_to_params(create_params, guest_token)
 
+        # flag source-group as "may have recordings" if source-object is present and recordings are actually possible
+        # create_params are expected to be lower case string values
+        if source_obj and create_params.get('record', 'false') == 'true':
+            source_obj.get_group_for_bbb_room().set_may_have_bbb_recordings()
+
         m_xml = self.bbb_api.start(
             name=self.name,
             meeting_id=self.meeting_id,
@@ -451,6 +456,11 @@ class BBBRoom(models.Model):
         # param exists
         guest_token = cls._generate_guest_token(source_object)
         create_params = cls.add_guest_link_moderator_only_message_to_params(create_params, guest_token)
+
+        # flag source-group as "may have recordings" if source-object is present and recordings are actually possible
+        # create_params are expected to be lower case string values
+        if source_object and create_params.get('record', 'false') == 'true':
+            source_object.get_group_for_bbb_room().set_may_have_bbb_recordings()
 
         m_xml = bbb_api.start(
             name=name,

--- a/cosinnus/models/group.py
+++ b/cosinnus/models/group.py
@@ -1539,8 +1539,6 @@ class CosinnusBaseGroup(
             return True
         if self.group_is_bbb_enabled:
             return True
-        if settings.COSINNUS_BBB_ENABLE_GROUP_AND_EVENT_BBB_ROOMS and 'premium_features_expired_on' in self.settings:
-            return True
         if self.settings.get('may_have_bbb_recordings', False):
             return True
         return False

--- a/cosinnus/models/group.py
+++ b/cosinnus/models/group.py
@@ -2033,6 +2033,24 @@ class CosinnusBaseGroup(
                     },
                 )
 
+    def set_may_have_bbb_recordings(self):
+        """
+        Saves a flag, that this group may have bbb recordings associated with it.
+
+        This flag is used by `group_can_access_recorded_meetings()` to determine if
+        the list of available recordings should be shown.
+        """
+
+        # do nothing if it is already set True
+        if self.settings.get('may_have_bbb_recordings', False):
+            return
+
+        self.settings.update({'may_have_bbb_recordings': True})
+        # update DB directly to avoid signals
+        type(self).objects.filter(pk=self.pk).update(settings=self.settings)
+        # group-cache must be cleared for the change to take effect
+        self.clear_cache()
+
 
 class CosinnusGroup(CosinnusBaseGroup):
     """Swappable group model implementation."""

--- a/cosinnus/models/group.py
+++ b/cosinnus/models/group.py
@@ -1539,6 +1539,8 @@ class CosinnusBaseGroup(
             return True
         if self.group_is_bbb_enabled:
             return True
+        if settings.COSINNUS_BBB_ENABLE_GROUP_AND_EVENT_BBB_ROOMS and 'premium_features_expired_on' in self.settings:
+            return True
         if self.settings.get('may_have_bbb_recordings', False):
             return True
         return False

--- a/cosinnus/models/group.py
+++ b/cosinnus/models/group.py
@@ -1525,13 +1525,23 @@ class CosinnusBaseGroup(
 
     @property
     def group_can_access_recorded_meetings(self):
-        """Check if the recorded meetings page should be shown and be accessible for this group, due to having
-        BBB enabled (and being premium if this portal requires ist) or being a conference."""
+        """
+        Returns True if this group may have BBB recordings associated with it.
+        This is determined by the flag `may_have_bbb_recordings` in `group.settings`, which is set when meetings are
+        created where recording is actually possible.
+
+        Returns True also, if this group is a conference or the group-specific BBB-room is enabled
+
+        Note: The current setting for this groups premium-state is ignored here,
+        so that created recordings remain accessible, regardless of how the settings are changed later.
+        """
         if self.group_is_conference:
             return True
         if self.group_is_bbb_enabled:
             return True
         if settings.COSINNUS_BBB_ENABLE_GROUP_AND_EVENT_BBB_ROOMS and 'premium_features_expired_on' in self.settings:
+            return True
+        if self.settings.get('may_have_bbb_recordings', False):
             return True
         return False
 


### PR DESCRIPTION
Streamlines the process of determining group access to BBB recordings.

- Sets a flag on the group when a BBB room is created with recording enabled, indicating potential recordings.
- Simplifies the access check to rely on this flag and group type (conference or BBB enabled) for determining whether to show the recordings page.

Fixes #447
https://git.wechange.de/gl/code/cooperation/-/issues/447