### PR TITLE
fix default BBB parameters-type

### DIFF
--- a/cosinnus/conf.py
+++ b/cosinnus/conf.py
@@ -1693,9 +1693,9 @@ class CosinnusDefaultSettings(AppConf):
 
     # the default BBB create-call parameters for all room types
     BBB_DEFAULT_CREATE_PARAMETERS = {
-        'record': False,
-        'autoStartRecording': False,
-        'allowStartStopRecording': True,
+        'record': 'false',
+        'autoStartRecording': 'false',
+        'allowStartStopRecording': 'true',
         'guestPolicy': 'ALWAYS_ACCEPT',  # always by default allow guest access
     }
 


### PR DESCRIPTION
Ensures the default BigBlueButton create parameters are strings

BBB-API expects all parameters to be strings, especially bool values to be lower case strings. Otherwise the behavior is undefined.

see: https://docs.bigbluebutton.org/development/api/#api-data-types

Also we parse these parameters ourselves and expect the same.

neccessary for: https://github.com/wechange-eg/cosinnus-core/pull/537
