### PR TITLE
#527 fix group list elements always disabled

### DIFF
--- a/cosinnus/templates/cosinnus/user/group_invite_token.html
+++ b/cosinnus/templates/cosinnus/user/group_invite_token.html
@@ -21,7 +21,7 @@
             </p>
             
             {% for group in invite_groups %}
-                {% include 'cosinnus/group/single_group.html' with group=group target_blank=True spaced=True disabled=True %}
+                {% include 'cosinnus/group/single_group.html' with group=group target_blank=True spaced=True disabled=group.is_active|negate %}
             {% endfor %}
         {% endcaptureas %}
         {% captureas title %}


### PR DESCRIPTION
- change invite view that group list elements are enabled/disabled depending on group.is_active

https://git.wechange.de/gl/code/cooperation/-/issues/527
