### PR TITLE
coop #368 Relocates marketplace category filters

### DIFF
--- a/cosinnus/static/less/general.less
+++ b/cosinnus/static/less/general.less
@@ -734,3 +734,23 @@ a.portal-inlink:hover img {
 		}
 	}
 }
+
+.marketplace-category-filter {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 1em;
+
+    .category_group {
+        display: flex;
+        align-items: baseline;
+    }
+
+    .category_list {
+        display: flex;
+        flex-wrap: wrap;
+
+        > div {
+            margin: 0 1em;
+        }
+    }
+}

--- a/cosinnus_marketplace/templates/cosinnus_marketplace/leftnav.html
+++ b/cosinnus_marketplace/templates/cosinnus_marketplace/leftnav.html
@@ -63,21 +63,6 @@
             </li>
         </ul>
     </button>
-
-    {% if user|can_create_objects_in:group %}
-        <button type="button" class="btn w100 btn-emphasized large-space" href="{{ marketplace_add_page }}">
-            <ul class="media-list">
-                <li class="media">
-                    <span class="pull-left">
-                        <i class="fa fa-plus"></i>
-                    </span>
-                    <div class="media-body">
-                        {% trans "Add Offer" %}
-                    </div>
-                </li>
-            </ul>
-        </button>
-    {% endif %}
 {% endif %}
 
 {% block leftnav_extra %}{% endblock leftnav_extra %}

--- a/cosinnus_marketplace/templates/cosinnus_marketplace/leftnav.html
+++ b/cosinnus_marketplace/templates/cosinnus_marketplace/leftnav.html
@@ -78,53 +78,6 @@
             </ul>
         </button>
     {% endif %}
-    
-    {% if filter.get_categories_grouped %}
-		<form action="." method="GET" class="regular-space clearfix" >
-		
-		    <!-- a box with semi transparent background -->
-		    <div class="content-box">
-		    	<input type="hidden" id="input_tab_param" name="tab" value="{{ request.GET.tab }}" />
-		    
-				{# set all existing filters as inputs for the GET request #}        
-		        {% for filter_key in 'o,creator'|makelist %}
-		        	{% for filter_value in filter.data|querydictlist:filter_key %}
-		        		<input type="hidden" name="{{ filter_key }}" value="{{ filter_value }}" />
-		        	{% endfor %}
-		        {% endfor %}
-		        
-	    		<div class="row large-space">
-	    			{% for group, categories in filter.get_categories_grouped %}
-			            <div class="col-xs-12 large-space">
-		    				<b>{% if group == 'zzz_misc' %}{% trans "Misc" %}{% else %}{{ group }}{% endif %}</b>
-				        	{% for category in categories %}
-				        		<br/>
-					            <label for="id_categories_{{ category.id }}">
-					            	<input id="id_categories_{{ category.id }}" name="categories" 
-					            			type="checkbox" value="{{ category.id }}"{% if category.id in filter.data|querydictlist:'categories' or category.id|stringify in filter.data|querydictlist:'categories' %}checked="checked"{% endif %}>
-					            	<span>{{ category.name }}</span>
-					        	</label>
-				        	{% endfor %}
-			        	</div>
-			        {% endfor %}
-		        </div>
-	    	</div>
-			<button type="submit" class="btn btn-emphasized large-space">
-	            <ul class="media-list">
-	                <li class="media">
-	                    <span class="pull-left">
-	                        <i class="fa fa-filter"></i>
-	                    </span>
-	                    <div class="media-body">
-	                        {% trans "Filter" %}
-	                    </div>
-	                </li>
-	            </ul>
-	        </button>        
-	        
-	    </form>
-    {% endif %}
-    
 {% endif %}
 
 {% block leftnav_extra %}{% endblock leftnav_extra %}

--- a/cosinnus_marketplace/templates/cosinnus_marketplace/offer_form.html
+++ b/cosinnus_marketplace/templates/cosinnus_marketplace/offer_form.html
@@ -90,7 +90,7 @@
     
     
         {% trans "Offer Title" as title_label %}
-        {% include 'cosinnus/fields/default_field.html' with field=form.forms.obj.title label=title_label placeholder=title_label %}
+        {% include 'cosinnus/fields/default_field.html' with field=form.forms.obj.title label=title_label placeholder=title_label field_value=request.GET.title %}
         
         
         {# SimpleMDE Description Field (gets initialized in extrahead) #}                                   

--- a/cosinnus_marketplace/templates/cosinnus_marketplace/offer_list.html
+++ b/cosinnus_marketplace/templates/cosinnus_marketplace/offer_list.html
@@ -16,10 +16,6 @@
 
 {% block content %}
 	{{ block.super }}
-	
-	{% comment %}  
-	Disabled for now to keep the view more compact. There is an add button in the left navbar.
-	
     {% if user|can_create_objects_in:group %} 
 	    <!-- a box with semi transparent background -->
 	    <div class="content-box regular-space">
@@ -55,8 +51,6 @@
 	        </form>
 	    </div>    
     {% endif %}
-	{% endcomment %}
-    
     
     {% trans "Delete" as btn_label %}
     {% captureas btn_action %}$.cosinnus.Feedback.cosinnus_delete_element($.cosinnus.getListOfCheckedItems());{% endcaptureas %}

--- a/cosinnus_marketplace/templates/cosinnus_marketplace/offer_list.html
+++ b/cosinnus_marketplace/templates/cosinnus_marketplace/offer_list.html
@@ -83,45 +83,11 @@
 
     <div class="content-box large-space">
         <div>
-            {#  filter-dropdowns are shown first in single column, second in two-column #}
-            <div class="offer-filter-dropdowns">
-                {% for field in filter.form %}
+            {% for field in filter.form %}
                 {% if field.name == 'creator' or field.name == 'o' %}
                     {{ field }}
                 {% endif %}
             {% endfor %}
-            </div>
-            {% if filter.get_categories_grouped %}
-                <div class="category-form-container">
-                    <form action="." method="GET">
-
-                        <input type="hidden" id="input_tab_param" name="tab" value="{{ request.GET.tab }}"/>
-
-                        {# set all existing filters as inputs for the GET request #}
-                        {% for filter_key in 'o,creator'|makelist %}
-                            {% for filter_value in filter.data|querydictlist:filter_key %}
-                                <input type="hidden" name="{{ filter_key }}" value="{{ filter_value }}"/>
-                            {% endfor %}
-                        {% endfor %}
-
-                        {% for group, categories in filter.get_categories_grouped %}
-                            <label><b>{% if group == 'zzz_misc' %}{% trans "Misc" %}{% else %}
-                                {{ group }}{% endif %}</b></label>
-
-                            {% for category in categories %}
-                                <label for="id_categories_{{ category.id }}">
-                                    <input id="id_categories_{{ category.id }}" name="categories"
-                                           onchange="this.form.submit()"
-                                           type="checkbox" value="{{ category.id }}"
-                                           {% if category.id in filter.data|querydictlist:'categories' or category.id|stringify in filter.data|querydictlist:'categories' %}checked="checked"{% endif %}>
-                                    <span>{{ category.name }}</span>
-                                </label>
-                            {% endfor %}
-                            <br/>
-                        {% endfor %}
-                    </form>
-                </div>
-            {% endif %}
 
             {% for filter_param, chosen_value, label, type in active_filters %}
                 <span class="inline-list nowrap">
@@ -136,7 +102,42 @@
 				        </span>
 				    </span>
             {% endfor %}
-		</div>
+            <div class="clearfix"></div>
+
+            {% if filter.get_categories_grouped %}
+                <form action="." method="GET">
+                    <input type="hidden" id="input_tab_param" name="tab" value="{{ request.GET.tab }}"/>
+                    {# set all existing filters as inputs for the GET request #}
+                    {% for filter_key in 'o,creator'|makelist %}
+                        {% for filter_value in filter.data|querydictlist:filter_key %}
+                            <input type="hidden" name="{{ filter_key }}" value="{{ filter_value }}"/>
+                        {% endfor %}
+                    {% endfor %}
+
+                    <div class="marketplace-category-filter">
+                        {% for group, categories in filter.get_categories_grouped %}
+                            <div class="category_group">
+                                <label><b>{% if group == 'zzz_misc' %}{% trans "Misc" %}{% else %}
+                                    {{ group }}{% endif %}</b></label>
+                                <div class="category_list">
+                                    {% for category in categories %}
+                                        <div>
+                                            <label for="id_categories_{{ category.id }}">
+                                                <input id="id_categories_{{ category.id }}" name="categories"
+                                                       onchange="this.form.submit()"
+                                                       type="checkbox" value="{{ category.id }}"
+                                                       {% if category.id in filter.data|querydictlist:'categories' or category.id|stringify in filter.data|querydictlist:'categories' %}checked="checked"{% endif %}>
+                                                <span>{{ category.name }}</span>
+                                            </label>
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        {% endfor %}
+                    </div>
+                </form>
+            {% endif %}
+        </div>
         
         <div class="tab-content">
 			<div class="tab-pane {% if not request.GET.tab or request.GET.tab == 'all' %}active{% endif %}" id="all" >

--- a/cosinnus_marketplace/templates/cosinnus_marketplace/offer_list.html
+++ b/cosinnus_marketplace/templates/cosinnus_marketplace/offer_list.html
@@ -86,26 +86,62 @@
 			</a>
 		</li>
 	</ul>
-	
+
     <div class="content-box large-space">
-    
-    	<div>
-		    {% for field in filter.form %}
-			    {% if field.name == 'creator' or field.name == 'o' %}
-			    	{{ field }}
-			    {% endif %}
-			{% endfor %}
-	        
-	        {% for filter_param, chosen_value, label, type in active_filters %}
-	        	{% if not filter_param == 'categories' %}
-				    <span class="inline-list nowrap">
-				        <a href="?{% strip_params request filter_param %}" class="app-background small-padding"><i class="fa fa-times"></i></a
-				        ><span class="app-background-light dark-color small-padding">
-				            {{ label }}: {{ chosen_value }}
+        <div>
+            {#  filter-dropdowns are shown first in single column, second in two-column #}
+            <div class="offer-filter-dropdowns">
+                {% for field in filter.form %}
+                {% if field.name == 'creator' or field.name == 'o' %}
+                    {{ field }}
+                {% endif %}
+            {% endfor %}
+            </div>
+            {% if filter.get_categories_grouped %}
+                <div class="category-form-container">
+                    <form action="." method="GET">
+
+                        <input type="hidden" id="input_tab_param" name="tab" value="{{ request.GET.tab }}"/>
+
+                        {# set all existing filters as inputs for the GET request #}
+                        {% for filter_key in 'o,creator'|makelist %}
+                            {% for filter_value in filter.data|querydictlist:filter_key %}
+                                <input type="hidden" name="{{ filter_key }}" value="{{ filter_value }}"/>
+                            {% endfor %}
+                        {% endfor %}
+
+                        {% for group, categories in filter.get_categories_grouped %}
+                            <label><b>{% if group == 'zzz_misc' %}{% trans "Misc" %}{% else %}
+                                {{ group }}{% endif %}</b></label>
+
+                            {% for category in categories %}
+                                <label for="id_categories_{{ category.id }}">
+                                    <input id="id_categories_{{ category.id }}" name="categories"
+                                           onchange="this.form.submit()"
+                                           type="checkbox" value="{{ category.id }}"
+                                           {% if category.id in filter.data|querydictlist:'categories' or category.id|stringify in filter.data|querydictlist:'categories' %}checked="checked"{% endif %}>
+                                    <span>{{ category.name }}</span>
+                                </label>
+                            {% endfor %}
+                            <br/>
+                        {% endfor %}
+                    </form>
+                </div>
+            {% endif %}
+
+            {% for filter_param, chosen_value, label, type in active_filters %}
+                <span class="inline-list nowrap">
+				        <a href="?{% strip_params request filter_param %}" class="app-background small-padding"><i
+                            class="fa fa-times"></i></a
+                        ><span class="app-background-light dark-color small-padding">
+				           {% if filter_param == 'categories' %}
+                               {{ label }}
+                           {% else %}
+                               {{ label }}: {{ chosen_value }}
+                           {% endif %}
 				        </span>
 				    </span>
-			    {% endif %}
-			{% endfor %}
+            {% endfor %}
 		</div>
         
         <div class="tab-content">


### PR DESCRIPTION
Moves marketplace category filters from the left navigation bar to the offer list.

Also includes:
- Replaces the add-button with an input field above the offer list.
- Introduces a flexbox layout for filter items.