### PR TITLE
bugfix: allow blank last name on signup if not required

### DIFF
--- a/cosinnus/api_frontend/serializers/user.py
+++ b/cosinnus/api_frontend/serializers/user.py
@@ -74,6 +74,7 @@ class CosinnusUserSignupSerializer(
     )
     last_name = serializers.CharField(
         required=bool(settings.COSINNUS_USER_FORM_LAST_NAME_REQUIRED),
+        allow_blank=not bool(settings.COSINNUS_USER_FORM_LAST_NAME_REQUIRED),
         validators=[MinLengthValidator(2), MaxLengthValidator(USER_NAME_FIELDS_MAX_LENGTH), validate_username],
     )
     if settings.COSINNUS_USERPROFILE_ENABLE_NEWSLETTER_OPT_IN:


### PR DESCRIPTION
Allows users to signup with a blank last name when the
`COSINNUS_USER_FORM_LAST_NAME_REQUIRED` setting is disabled.
