### PR TITLE
Add report button to comment sections across apps

### DIFF
--- a/cosinnus_event/templates/cosinnus_event/event_comments.html
+++ b/cosinnus_event/templates/cosinnus_event/event_comments.html
@@ -65,7 +65,7 @@
                                     {% if user|has_write_access:comment %}
                                         <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:event:comment-delete' group=comment.event.group pk=comment.pk %}" method="post" class="form-horizontal">
                                             {% csrf_token %}
-                                            <a class="pull-right" onclick="$('#delete_comment_form_{{ comment.pk }}').submit(); return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
+                                            <a class="pull-right" href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
                                         </form>
                                     {% endif %}
                                 </div>

--- a/cosinnus_event/templates/cosinnus_event/event_comments.html
+++ b/cosinnus_event/templates/cosinnus_event/event_comments.html
@@ -62,11 +62,14 @@
                                 <strong><a href="{{ comment.creator|profile_url }}">{{ comment.creator|full_name }}</a></strong>
                                 <a href="{{ comment.get_absolute_url }}"><span class="annotation moment-data-date" data-date="{{ comment.created_on|date:'c' }}" ></span></a>
                                 <div class="font11px regular-space">
+                                    <span class="pull-right">{% include 'cosinnus/feedback/report_button_a.html' with object=comment %}</span>
                                     {% if user|has_write_access:comment %}
-                                        <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:event:comment-delete' group=comment.event.group pk=comment.pk %}" method="post" class="form-horizontal">
-                                            {% csrf_token %}
-                                            <a class="pull-right" href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
-                                        </form>
+                                        <span class="pull-right">
+                                            <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:event:comment-delete' group=comment.event.group pk=comment.pk %}" method="post" class="form-horizontal">
+                                                {% csrf_token %}
+                                                <a href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
+                                            </form>
+                                        </span>
                                     {% endif %}
                                 </div>
                                 <div class="comment-background textfield">{{ comment.text|textfield }}</div>

--- a/cosinnus_marketplace/templates/cosinnus_marketplace/offer_comments.html
+++ b/cosinnus_marketplace/templates/cosinnus_marketplace/offer_comments.html
@@ -65,7 +65,7 @@
                                     {% if user|has_write_access:comment %}
                                         <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:marketplace:comment-delete' group=comment.offer.group pk=comment.pk %}" method="post" class="form-horizontal">
                                             {% csrf_token %}
-                                            <a class="pull-right" href="#" onclick="$('#delete_comment_form_{{ comment.pk }}').submit(); return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
+                                            <a class="pull-right" href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
                                         </form>
                                     {% endif %}
                                 </div>

--- a/cosinnus_marketplace/templates/cosinnus_marketplace/offer_comments.html
+++ b/cosinnus_marketplace/templates/cosinnus_marketplace/offer_comments.html
@@ -62,11 +62,14 @@
                                 <strong><a href="{{ comment.creator|profile_url }}">{{ comment.creator|full_name }}</a></strong>
                                 <a href="{{ comment.get_absolute_url }}"><span class="annotation moment-data-date" data-date="{{ comment.created_on|date:'c' }}" ></span></a>
                                 <div class="font11px regular-space">
+                                    <span class="pull-right">{% include 'cosinnus/feedback/report_button_a.html' with object=comment %}</span>
                                     {% if user|has_write_access:comment %}
-                                        <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:marketplace:comment-delete' group=comment.offer.group pk=comment.pk %}" method="post" class="form-horizontal">
-                                            {% csrf_token %}
-                                            <a class="pull-right" href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
-                                        </form>
+                                        <span class="pull-right">
+                                            <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:marketplace:comment-delete' group=comment.offer.group pk=comment.pk %}" method="post" class="form-horizontal">
+                                                {% csrf_token %}
+                                                <a href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
+                                            </form>
+                                        </span>
                                     {% endif %}
                                 </div>
                                 <div class="comment-background textfield">{{ comment.text|textfield }}</div>

--- a/cosinnus_note/templates/cosinnus_note/note_comments.html
+++ b/cosinnus_note/templates/cosinnus_note/note_comments.html
@@ -61,13 +61,16 @@
                             <div class="media-body comment-background">
                                 <strong><a href="{{ comment.creator|profile_url }}">{{ comment.creator|full_name }}</a></strong>
                                 <div class="font11px regular-space">
+                                    <span class="pull-right">{% include 'cosinnus/feedback/report_button_a.html' with object=comment %}</span>
                                     {% if user|has_write_access:comment %}
-                                    	{% comment %} Force the URL of the POST to remain on this site because of CSRF checks, but
-            				  						  force the cosinnus group resolution to check the group of this portal {% endcomment %}
-                                        <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:note:comment-delete' group=comment.note.group pk=comment.pk force_local_domain="True" %}" method="post" class="form-horizontal">
-                                            {% csrf_token %}{% cosinnus_cross_portal_token comment.note.group.portal %}
-                                            <a class="pull-right" href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
-                                        </form>
+                                        <span class="pull-right">
+                                            {% comment %} Force the URL of the POST to remain on this site because of CSRF checks, but
+                                                          force the cosinnus group resolution to check the group of this portal {% endcomment %}
+                                            <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:note:comment-delete' group=comment.note.group pk=comment.pk force_local_domain="True" %}" method="post" class="form-horizontal">
+                                                {% csrf_token %}{% cosinnus_cross_portal_token comment.note.group.portal %}
+                                                <a href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
+                                            </form>
+                                        </span>
                                     {% endif %}
                                     <a href="{{ comment.get_absolute_url }}"><span class="moment-data-date" data-date="{{ comment.created_on|date:'c' }}" ></span></a>
                                 </div>

--- a/cosinnus_note/templates/cosinnus_note/note_comments.html
+++ b/cosinnus_note/templates/cosinnus_note/note_comments.html
@@ -66,7 +66,7 @@
             				  						  force the cosinnus group resolution to check the group of this portal {% endcomment %}
                                         <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:note:comment-delete' group=comment.note.group pk=comment.pk force_local_domain="True" %}" method="post" class="form-horizontal">
                                             {% csrf_token %}{% cosinnus_cross_portal_token comment.note.group.portal %}
-                                            <a class="pull-right" href="#" onclick="$('#delete_comment_form_{{ comment.pk }}').submit(); return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
+                                            <a class="pull-right" href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
                                         </form>
                                     {% endif %}
                                     <a href="{{ comment.get_absolute_url }}"><span class="moment-data-date" data-date="{{ comment.created_on|date:'c' }}" ></span></a>

--- a/cosinnus_poll/templates/cosinnus_poll/poll_comments.html
+++ b/cosinnus_poll/templates/cosinnus_poll/poll_comments.html
@@ -65,7 +65,7 @@
                                     {% if user|has_write_access:comment %}
                                         <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:poll:comment-delete' group=comment.poll.group pk=comment.pk %}" method="post" class="form-horizontal">
                                             {% csrf_token %}
-                                            <a class="pull-right" href="#" onclick="$('#delete_comment_form_{{ comment.pk }}').submit(); return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
+                                            <a class="pull-right" href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
                                         </form>
                                     {% endif %}
                                 </div>

--- a/cosinnus_poll/templates/cosinnus_poll/poll_comments.html
+++ b/cosinnus_poll/templates/cosinnus_poll/poll_comments.html
@@ -62,11 +62,14 @@
                                 <strong><a href="{{ comment.creator|profile_url }}">{{ comment.creator|full_name }}</a></strong>
                                 <a href="{{ comment.get_absolute_url }}"><span class="annotation moment-data-date" data-date="{{ comment.created_on|date:'c' }}" ></span></a>
                                 <div class="font11px regular-space">
+                                    <span class="pull-right">{% include 'cosinnus/feedback/report_button_a.html' with object=comment %}</span>
                                     {% if user|has_write_access:comment %}
-                                        <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:poll:comment-delete' group=comment.poll.group pk=comment.pk %}" method="post" class="form-horizontal">
-                                            {% csrf_token %}
-                                            <a class="pull-right" href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
-                                        </form>
+                                        <span class="pull-right">
+                                            <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:poll:comment-delete' group=comment.poll.group pk=comment.pk %}" method="post" class="form-horizontal">
+                                                {% csrf_token %}
+                                                <a href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
+                                            </form>
+                                        </span>
                                     {% endif %}
                                 </div>
                                 <div class="comment-background textfield">{{ comment.text|textfield }}</div>

--- a/cosinnus_todo/templates/cosinnus_todo/todo_comments.html
+++ b/cosinnus_todo/templates/cosinnus_todo/todo_comments.html
@@ -62,11 +62,14 @@
                                 <strong><a href="{{ comment.creator|profile_url }}">{{ comment.creator|full_name }}</a></strong>
                                 <a href="{{ comment.get_absolute_url }}"><span class="annotation moment-data-date" data-date="{{ comment.created_on|date:'c' }}" ></span></a>
                                 <div class="font11px regular-space">
+                                    <span class="pull-right">{% include 'cosinnus/feedback/report_button_a.html' with object=comment %}</span>
                                     {% if user|has_write_access:comment %}
-                                        <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:todo:comment-delete' group=comment.todo.group pk=comment.pk %}" method="post" class="form-horizontal">
-                                            {% csrf_token %}
-                                            <a class="pull-right" href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
-                                        </form>
+                                        <span class="pull-right">
+                                            <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:todo:comment-delete' group=comment.todo.group pk=comment.pk %}" method="post" class="form-horizontal">
+                                                {% csrf_token %}
+                                                <a href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
+                                            </form>
+                                        </span>
                                     {% endif %}
                                 </div>
                                 <div class="comment-background textfield">{{ comment.text|textfield }}</div>

--- a/cosinnus_todo/templates/cosinnus_todo/todo_comments.html
+++ b/cosinnus_todo/templates/cosinnus_todo/todo_comments.html
@@ -65,7 +65,7 @@
                                     {% if user|has_write_access:comment %}
                                         <form id="delete_comment_form_{{ comment.pk }}" action="{% group_url 'cosinnus:todo:comment-delete' group=comment.todo.group pk=comment.pk %}" method="post" class="form-horizontal">
                                             {% csrf_token %}
-                                            <a class="pull-right" href="#" onclick="$('#delete_comment_form_{{ comment.pk }}').submit(); return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
+                                            <a class="pull-right" href="#" onclick="if(window.confirm('{% trans "Are you sure you want to delete the item?" %}')){$('#delete_comment_form_{{ comment.pk }}').submit();} return false;" title="{% trans "Delete" %}"><i class="fa fa-times"></i></a>
                                         </form>
                                     {% endif %}
                                 </div>


### PR DESCRIPTION
Adds content reporting functionality to comments in event, marketplace, note, poll, and todo modules. Wraps delete buttons in span elements to properly align with the new report button.

https://git.wechange.de/gl/code/cooperation/-/issues/572