### PR TITLE
feat: make users visible in group-invite-select2 fields, omitting blocked users

### DIFF
--- a/cosinnus/tests/util_tests/test_permissions.py
+++ b/cosinnus/tests/util_tests/test_permissions.py
@@ -1,0 +1,80 @@
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
+from django.test import TestCase, override_settings
+
+from cosinnus.models import UserBlock
+from cosinnus.utils.permissions import check_user_blocks_user, filter_blocks_for_user
+
+User = get_user_model()
+
+
+@override_settings(COSINNUS_ENABLE_USER_BLOCK=True)
+class UserBlockTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user_main = User.objects.create(username='main_user')
+        cls.user_blocked_by_main = User.objects.create(username='blocked_by_main')
+        cls.user_blocking_main = User.objects.create(username='blocking_main')
+        cls.user_neutral = User.objects.create(username='neutral_user')
+        cls.user_anonymous = AnonymousUser()
+
+        # main user blocks other user
+        UserBlock.objects.create(user=cls.user_main, blocked_user=cls.user_blocked_by_main)
+        # main user us blocked by other user
+        UserBlock.objects.create(user=cls.user_blocking_main, blocked_user=cls.user_main)
+
+    @override_settings(COSINNUS_ENABLE_USER_BLOCK=False)
+    def test_filter_blocks_nop_if_blocking_disabled(self):
+        all_users = User.objects.all()
+
+        # given queryset is returned
+        filtered_qs = filter_blocks_for_user(self.user_main, all_users)
+        self.assertEqual(filtered_qs, all_users)
+
+    def test_filter_blocks_for_user_removes_both_ways(self):
+        all_users = User.objects.all()
+        filtered_qs = filter_blocks_for_user(self.user_main, all_users)
+
+        # only main user and neutral user remain
+        self.assertEqual(filtered_qs.count(), 2)
+        self.assertIn(self.user_main, filtered_qs)
+        self.assertIn(self.user_neutral, filtered_qs)
+
+    def test_filter_blocks_nop_for_anonymous_user(self):
+        all_users = User.objects.all()
+
+        # given queryset is returned
+        filtered_qs = filter_blocks_for_user(self.user_anonymous, all_users)
+        self.assertEqual(filtered_qs, all_users)
+
+    def test_filter_blocks_for_user_with_empty_queryset(self):
+        empty_qs = User.objects.none()
+        filtered_qs = filter_blocks_for_user(self.user_main, empty_qs)
+
+        self.assertEqual(filtered_qs.count(), 0)
+
+    def test_check_user_blocks_user_is_true(self):
+        result = check_user_blocks_user(self.user_main, self.user_blocked_by_main)
+        self.assertTrue(result)
+
+    def test_check_user_blocks_user_is_false_for_neutral(self):
+        result = check_user_blocks_user(self.user_main, self.user_neutral)
+        self.assertFalse(result)
+
+    @override_settings(COSINNUS_ENABLE_USER_BLOCK=False)
+    def test_check_user_blocks_user_returns_false_if_feature_disabled(self):
+        # returns False despite an existing block
+        result = check_user_blocks_user(self.user_main, self.user_blocked_by_main)
+        self.assertFalse(result)
+
+    def test_check_user_blocks_user_unsaved_users(self):
+        unsaved_user = User(username='unsaved')
+
+        # returns False for unsaved user
+        result = check_user_blocks_user(self.user_main, unsaved_user)
+        self.assertFalse(result)
+
+    def test_check_user_blocks_user_anonymous(self):
+        # returns False for unsaved user
+        result = check_user_blocks_user(self.user_main, self.user_anonymous)
+        self.assertFalse(result)

--- a/cosinnus/utils/permissions.py
+++ b/cosinnus/utils/permissions.py
@@ -2,12 +2,15 @@
 from __future__ import unicode_literals
 
 from builtins import str
+from typing import Union
 from uuid import uuid1
 
 from annoying.functions import get_object_or_None
 from django.conf import settings
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ImproperlyConfigured
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q, QuerySet
 from rest_framework.authentication import get_authorization_header
 from rest_framework.permissions import BasePermission, IsAdminUser
 
@@ -262,6 +265,34 @@ def check_user_can_see_user(user, target_user, is_invite_selection=False):
     if any([(user_group_pk in target_user_groups) for user_group_pk in user_groups]):
         return True
     return False
+
+
+def filter_blocks_for_user(
+    user: Union[AbstractBaseUser, AnonymousUser], users: QuerySet[AbstractBaseUser]
+) -> QuerySet[AbstractBaseUser]:
+    """
+    Filters a given Queryset so the result does not include any users,
+    who are blocked by or who have blocked the given user.
+
+    Returns the given QuerySet unchanged if
+    - user blocking is not active
+    - user argument is AnonymousUser
+    """
+    if not settings.COSINNUS_ENABLE_USER_BLOCK or isinstance(user, AnonymousUser):
+        return users
+
+    # we want this query but django uses one subquery per condition
+    # filtered = users.exclude(
+    #     Q(user_blocks__blocked_user=user) | Q(blocked_by__user=user)
+    # ).distinct()
+
+    # instead optimize the DB-Query to only have one subquery for both conditions
+    blocking_relations = UserBlock.objects.filter(
+        (Q(user=OuterRef('pk')) & Q(blocked_user=user)) | (Q(user=user) & Q(blocked_user=OuterRef('pk')))
+    )
+    filtered = users.filter(~Exists(blocking_relations))
+
+    return filtered
 
 
 def check_user_blocks_user(blocking_user, blocked_user):

--- a/cosinnus/utils/permissions.py
+++ b/cosinnus/utils/permissions.py
@@ -210,11 +210,14 @@ def check_object_likefollowstar_access(obj, user):
     return is_group or check_object_read_access(obj, user)
 
 
-def check_user_can_see_user(user, target_user):
-    """Checks if ``user`` is in any relation with ``target_user`` so that he can see them and
+def check_user_can_see_user(user, target_user, is_invite_selection=False):
+    """
+    Checks if ``user`` is in any relation with ``target_user`` so that he can see them and
     their profile, and can send him messages, etc.
-    This depends on the privacy settings of ``target_user`` and on whether they are members
-    of a same group/project."""
+    - This depends on the privacy settings of ``target_user`` and on whether they are members
+    of a same group/project.
+    - if `is_invite_selection` is True, return True ignoring the profile visibility setting
+    """
     # you can always see yourself
     if user.id == target_user.id:
         return True
@@ -226,6 +229,10 @@ def check_user_can_see_user(user, target_user):
         target_user_tagslugs = target_user.cosinnus_profile.get_managed_tag_slugs()
         if any([tagslug in target_user_tagslugs for tagslug in settings.COSINNUS_MANAGED_TAGS_RESTRICT_CONTACTING]):
             return False
+
+    # when selecting for invitations, we ignore visibility settings
+    if is_invite_selection:
+        return True
 
     visibility = target_user.cosinnus_profile.media_tag.visibility
     if visibility == BaseTagObject.VISIBILITY_ALL:

--- a/cosinnus/views/group.py
+++ b/cosinnus/views/group.py
@@ -103,6 +103,7 @@ from cosinnus.utils.permissions import (
     check_user_can_create_conferences,
     check_user_can_see_user,
     check_user_superuser,
+    filter_blocks_for_user,
 )
 from cosinnus.utils.urls import group_aware_reverse, redirect_next_or
 from cosinnus.utils.user import (
@@ -2228,11 +2229,13 @@ class UserGroupMemberInviteSelect2View(RequireReadMixin, Select2View):
 
         users = self.get_user_queryset(terms)
 
+        # filter out users who have active userblocks, both directions
+        users = filter_blocks_for_user(request.user, users)
+
         users = prioritize_suggestions_output(request, users)
 
-        # as a last filter, remove all users that that have their privacy setting to "only members of groups i am in",
-        # if they aren't in a group with the user
-        users = [user for user in users if check_user_can_see_user(request.user, user)]
+        # as a last filter, remove users we can not see
+        users = [user for user in users if check_user_can_see_user(request.user, user, is_invite_selection=True)]
 
         # check for a direct email match
         direct_email_user = get_user_by_email_safe(term)


### PR DESCRIPTION
- show users in group invite select2 suggestions, ignoring profile visibility setting
- Prevents blocked users from being suggested (both ways)
- tests for utility-functions

https://git.wechange.de/gl/code/portals/wechange/-/issues/1859