### PR TITLE
fix(style): resolve white text error messages being invisible in white design

### DIFF
--- a/cosinnus/static/less/extra_designs/white_design.less
+++ b/cosinnus/static/less/extra_designs/white_design.less
@@ -321,6 +321,13 @@ div[data-target="widget-content"] {
     }
 }
 
+/* Fix font color for form fiel-error messages */
+ul.errorlist {
+	li {
+        color: #FFFFFF;
+	}
+}
+
 
 /* Condensed radio input fixes */
 .condensed-radio-input {


### PR DESCRIPTION
Form field error messages now display in white color to ensure visibility against dark backgrounds in the white design theme.

https://git.wechange.de/gl/code/portals/wechange/-/issues/1641
