### PR TITLE
feat: add configurable user display names in email notifications

### DIFF
--- a/cosinnus/conf.py
+++ b/cosinnus/conf.py
@@ -943,6 +943,10 @@ class CosinnusConf(AppConf):
     # nextcloud and rocketchat receive for that user
     EXTERNAL_USER_DISPLAY_NAME_FUNC = None
 
+    # can be set to a function receiving `user` as only argument,
+    # to modify the user display name used in email notifications
+    EMAIL_USER_DISPLAY_NAME_FUNC = None
+
     # if set to True, regular non-portal admin users can not create projects and groups by themselves
     # and some elements like the "+" button in the navbar is hidden
     LIMIT_PROJECT_AND_GROUP_CREATION_TO_ADMINS = False

--- a/cosinnus/models/profile.py
+++ b/cosinnus/models/profile.py
@@ -316,6 +316,13 @@ class BaseUserProfile(
             return display_name_func(self.user)
         return self.get_full_name()
 
+    def get_full_name_in_mail(self):
+        """Return the display name for use as sender name when sending emails"""
+        display_name_func = settings.COSINNUS_EMAIL_USER_DISPLAY_NAME_FUNC
+        if display_name_func is not None and callable(display_name_func):
+            return display_name_func(self.user)
+        return self.get_full_name()
+
     def save(self, *args, **kwargs):
         created = bool(self.pk is None)
         # sanity check for missing media_tag:

--- a/cosinnus/templatetags/cosinnus_tags.py
+++ b/cosinnus/templatetags/cosinnus_tags.py
@@ -250,6 +250,27 @@ def full_name_force(value):
 
 
 @register.filter
+def full_name_in_mail(value):
+    """Template filter to get a readable name for the given user.
+    Returns the users full name for use in emails which may have additional information.
+
+    .. code-block:: django
+
+        {{ user|full_name }}
+
+    :param AbstractBaseUser value: the user object
+    :return: either the full user name or the login user name, or (Deleted User) if the user is inactive.
+    """
+    from django.contrib.auth.models import AbstractBaseUser
+
+    if isinstance(value, AbstractBaseUser):
+        if hasattr(value, 'cosinnus_profile') and value.cosinnus_profile:
+            return value.cosinnus_profile.get_full_name_in_mail()
+        return value.get_full_name()
+    return ''
+
+
+@register.filter
 def profile_url(value):
     """Template filter to get the profile page url for a given user
 

--- a/cosinnus/tests/core_tests/test_configurable_username_in_emails.py
+++ b/cosinnus/tests/core_tests/test_configurable_username_in_emails.py
@@ -1,0 +1,119 @@
+from collections import defaultdict
+from unittest.mock import MagicMock, patch
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+
+from cosinnus.templatetags.cosinnus_tags import full_name_in_mail
+from cosinnus_notifications.notifications import NotificationsThread, render_digest_item_for_notification_event
+
+User = get_user_model()
+
+TEST_USER_DATA = {'username': '1', 'email': 'testuser@example.com', 'first_name': 'Test', 'last_name': 'User'}
+TEST_NOTIFICATION_TYPE = {'test_notification': defaultdict(lambda: None, data_attributes=defaultdict(lambda: None))}
+
+DEFAULT_USER_NAME = f'{TEST_USER_DATA["first_name"]} {TEST_USER_DATA["last_name"]}'
+CUSTOM_USER_NAME = f'CUSTOM {DEFAULT_USER_NAME}'
+
+
+def custom_name_func(user):
+    """custom name function for testing"""
+    return CUSTOM_USER_NAME
+
+
+class GetFullNameInMailTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(**TEST_USER_DATA)
+
+    def test_default_behavior(self):
+        result = self.user.cosinnus_profile.get_full_name_in_mail()
+
+        self.assertEqual(result, DEFAULT_USER_NAME)
+
+    @override_settings(COSINNUS_EMAIL_USER_DISPLAY_NAME_FUNC=None)
+    def test_none_setting_uses_default(self):
+        result = self.user.cosinnus_profile.get_full_name_in_mail()
+
+        self.assertEqual(result, DEFAULT_USER_NAME)
+
+    @override_settings(COSINNUS_EMAIL_USER_DISPLAY_NAME_FUNC=custom_name_func)
+    def test_custom_function_takes_effect(self):
+        result = self.user.cosinnus_profile.get_full_name_in_mail()
+
+        self.assertEqual(result, CUSTOM_USER_NAME)
+
+
+class FullNameInMailTemplateTagTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(**TEST_USER_DATA)
+
+    def test_default_behavior(self):
+        result = full_name_in_mail(self.user)
+
+        self.assertEqual(result, DEFAULT_USER_NAME)
+
+    @override_settings(COSINNUS_EMAIL_USER_DISPLAY_NAME_FUNC=None)
+    def test_none_setting_uses_default(self):
+        result = full_name_in_mail(self.user)
+
+        self.assertEqual(result, DEFAULT_USER_NAME)
+
+    @override_settings(COSINNUS_EMAIL_USER_DISPLAY_NAME_FUNC=custom_name_func)
+    def test_custom_function_takes_effect(self):
+        """Test custom display name function"""
+        result = full_name_in_mail(self.user)
+
+        self.assertEqual(result, CUSTOM_USER_NAME)
+
+    def test_user_no_profile_fallback(self):
+        self.user.cosinnus_profile = None
+        self.user.save()
+
+        result = full_name_in_mail(self.user)
+
+        self.assertEqual(result, DEFAULT_USER_NAME)
+
+
+@override_settings(COSINNUS_EMAIL_USER_DISPLAY_NAME_FUNC=custom_name_func)
+class NotificationThreadTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create_user(**TEST_USER_DATA)
+
+        mock_notification_event = MagicMock()
+        mock_notification_event.user = cls.user
+        cls.mock_notification_event = mock_notification_event
+
+    @patch('cosinnus_notifications.notifications.render_to_string')
+    @patch('cosinnus_notifications.notifications.send_mail_or_fail')
+    def test_send_instant_uses_custom_name(self, mock_send_mail, mock_render_to_string):
+        # setup mock self for NotificationsThread
+        # this is hacky but the notifications module is not test-friendly at the moment
+        mock_self = MagicMock()
+        mock_self.user = self.user
+        mock_self.notification_preference_triggered = None
+        mock_self.options = {'mail_template': None, 'subject_template': None}
+        mock_self.sender.request = None
+        mock_self.obj = None
+
+        # trigger the notification with the mocked self object
+        NotificationsThread.send_instant_notification(mock_self, self.mock_notification_event, self.user)
+
+        args, kwargs = mock_send_mail.call_args
+        data_arg = args[3]
+        self.assertEqual(data_arg['sender_name'], CUSTOM_USER_NAME)
+        self.assertIn(CUSTOM_USER_NAME, kwargs['from_email'])
+
+    @patch.dict('cosinnus_notifications.notifications.notifications', TEST_NOTIFICATION_TYPE)
+    def test_render_digest_uses_custom_name(self):
+        # render_digest_item needs notification_id set to a valid notification type
+        # we use a mocked notification_type
+        self.mock_notification_event.notification_id = 'test_notification'
+
+        alert_data = render_digest_item_for_notification_event(
+            self.mock_notification_event, only_compile_alert_data=True
+        )
+
+        self.assertEqual(alert_data['string_variables']['sender_name'], CUSTOM_USER_NAME)

--- a/cosinnus_notifications/notifications.py
+++ b/cosinnus_notifications/notifications.py
@@ -34,7 +34,7 @@ from cosinnus.models.group import CosinnusGroup, CosinnusPortal
 from cosinnus.models.group_extra import CosinnusProject, CosinnusSociety
 from cosinnus.models.profile import GlobalUserNotificationSetting
 from cosinnus.models.tagged import BaseTaggableObjectModel
-from cosinnus.templatetags.cosinnus_tags import full_name, textfield
+from cosinnus.templatetags.cosinnus_tags import full_name, full_name_in_mail, textfield
 from cosinnus.utils.files import get_image_url_for_icon
 from cosinnus.utils.functions import ensure_dict_keys, resolve_attributes
 from cosinnus.utils.group import get_cosinnus_group_model, get_default_user_group_slugs
@@ -771,7 +771,7 @@ class NotificationsThread(CosinnusWorkerThread):
                         'receiver': receiver,
                         'receiver_name': mark_safe(strip_tags(full_name(receiver))),
                         'sender': self.user,
-                        'sender_name': mark_safe(strip_tags(full_name(self.user))),
+                        'sender_name': mark_safe(strip_tags(full_name_in_mail(self.user))),
                         'object': self.obj,
                         'notification_settings_url': mark_safe(preference_url),
                     }
@@ -791,7 +791,7 @@ class NotificationsThread(CosinnusWorkerThread):
             # strip anything unusual from the sender's name and any formatting interfering with the header
             portal_name = force_str(_(settings.COSINNUS_BASE_PAGE_TITLE_TRANS))
             username = (
-                strip_tags(full_name(notification_event.user))
+                strip_tags(full_name_in_mail(notification_event.user))
                 .replace(',', '')
                 .replace('.', '')
                 .replace('<', '')
@@ -946,12 +946,12 @@ def render_digest_item_for_notification_event(
             return '<div>stub: event "%s" with object "%s" from user "%s"</div>' % (
                 notification_event.notification_id,
                 getattr(obj, 'text', getattr(obj, 'title', getattr(obj, 'name', 'NOARGS'))),
-                notification_event.user.get_full_name(),
+                notification_event.user.get_full_name_in_mail(),
             )
             """
         data_attributes = options['data_attributes']
 
-        sender_name = mark_safe(strip_tags(full_name(notification_event.user)))
+        sender_name = mark_safe(strip_tags(full_name_in_mail(notification_event.user)))
         # add special attributes to object
         obj._sender_name = sender_name
         obj._sender = notification_event.user


### PR DESCRIPTION
- Add `COSINNUS_EMAIL_USER_DISPLAY_NAME_FUNC` setting to customize sender names in emails
- Add `get_full_name_in_mail()` method and `full_name_in_mail` template filter
- Update notification system to use custom display names for email senders
- Add tests for custom email display name functionality

https://git.wechange.de/gl/code/portals/boell/-/issues/75
