### PR TITLE
Fix notification settings test reliability

### DIFF
--- a/cosinnus/tests/model_tests/test_notification_settings.py
+++ b/cosinnus/tests/model_tests/test_notification_settings.py
@@ -203,7 +203,7 @@ class UserNotificationSettingAPITest(APITestCase):
 
     @override_settings(COSINNUS_ROCKET_ENABLED=True)
     @patch('cosinnus_message.utils.utils.save_rocketchat_mail_notification_preference_for_user_setting')
-    def test_rocketchat_error_on_setting_never_globally(self, mock_save_rc_settings):
+    def test_rocketchat_error_as_warning_in_response(self, mock_save_rc_settings):
         new_settings = {'setting': 0, 'portal_group_setting': 0}
 
         self.client.force_authenticate(user=self.user)
@@ -222,12 +222,6 @@ class UserNotificationSettingAPITest(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertListEqual(response.data['warnings'], [ERROR_MESSAGE])
-
-        # local data has been changed
-        notification_setting = GlobalUserNotificationSetting.objects.get_object_for_user(user=self.user)
-        self.assertEqual(notification_setting.setting, 0)
-        self.assertEqual(notification_setting.portal_group_setting, 0)
-        self.assertEqual(notification_setting.rocketchat_setting, 0)
 
 
 @mock.patch(

--- a/cosinnus/tests/model_tests/test_notification_settings.py
+++ b/cosinnus/tests/model_tests/test_notification_settings.py
@@ -2,6 +2,7 @@ from unittest import mock, skip
 from unittest.mock import patch
 
 import django
+from django.contrib.auth import get_user_model
 from django.core.cache import cache
 from django.test import TestCase, override_settings
 from django.urls import reverse
@@ -15,12 +16,25 @@ from cosinnus.tests.factories import ActiveUserFactory
 from cosinnus_notifications.views import apply_global_notification_settings
 
 ERROR_MESSAGE = 'Error Message'
+User = get_user_model()
+
+
+def init_notification_settings_for_user(
+    user: User, *, setting: int, portal_group_setting: int, rocketchat_setting: int
+) -> None:
+    """init GlobalUserNotificationSetting for given user since override_settings has no effect on the model defaults"""
+    settings_obj: GlobalUserNotificationSetting = user.cosinnus_notification_settings.get()
+    settings_obj.setting = setting
+    settings_obj.portal_group_setting = portal_group_setting
+    settings_obj.rocketchat_setting = rocketchat_setting
+    settings_obj.save()
 
 
 class GlobalUserNotificationSettingsTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = ActiveUserFactory()
+        init_notification_settings_for_user(cls.user, setting=3, portal_group_setting=0, rocketchat_setting=0)
 
     @classmethod
     def tearDownClass(cls):
@@ -36,7 +50,9 @@ class GlobalUserNotificationSettingsTest(TestCase):
             GlobalUserNotificationSetting.objects.create(user=self.user, portal=portal)
 
     def test_creation_default_values(self):
-        notification_setting = GlobalUserNotificationSetting.objects.get_object_for_user(user=self.user)
+        # not using user-object from test-data because we want the portal-configured default-settings
+        default_user = ActiveUserFactory()
+        notification_setting = GlobalUserNotificationSetting.objects.get_object_for_user(user=default_user)
 
         with self.subTest(setting='setting'):
             self.assertEqual(notification_setting.setting, settings.COSINNUS_DEFAULT_GLOBAL_NOTIFICATION_SETTING)
@@ -45,14 +61,12 @@ class GlobalUserNotificationSettingsTest(TestCase):
                 notification_setting.rocketchat_setting, settings.COSINNUS_DEFAULT_ROCKETCHAT_NOTIFICATION_SETTING
             )
 
-    @override_settings(COSINNUS_DEFAULT_GLOBAL_NOTIFICATION_SETTING=0)
     def test_creation_valid_global_setting(self):
         notification_setting = GlobalUserNotificationSetting.objects.get_object_for_user(user=self.user)
         notification_setting.setting = 1
         notification_setting.save()
         self.assertEqual(notification_setting.setting, 1)
 
-    @override_settings(COSINNUS_DEFAULT_ROCKETCHAT_NOTIFICATION_SETTING=0)
     def test_creation_valid_rocketchat_setting(self):
         notification_setting = GlobalUserNotificationSetting.objects.get_object_for_user(user=self.user)
         notification_setting.rocketchat_setting = 1
@@ -70,13 +84,11 @@ class GlobalUserNotificationSettingsTest(TestCase):
         patched_clear_cache_for_user.assert_called_once()
 
 
-@override_settings(
-    COSINNUS_DEFAULT_GLOBAL_NOTIFICATION_SETTING_PORTAL_GROUP=0, COSINNUS_DEFAULT_GLOBAL_NOTIFICATION_SETTING=3
-)
 class TestGlobalUserSerializer(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = ActiveUserFactory()
+        init_notification_settings_for_user(cls.user, setting=3, portal_group_setting=0, rocketchat_setting=0)
 
     def test_serialize_notification_setting(self):
         notification_setting = GlobalUserNotificationSetting.objects.get_object_for_user(user=self.user)
@@ -99,13 +111,12 @@ class TestGlobalUserSerializer(TestCase):
         self.assertEqual(notification_setting.rocketchat_setting, 5)
 
 
-@override_settings(
-    COSINNUS_DEFAULT_GLOBAL_NOTIFICATION_SETTING_PORTAL_GROUP=0, COSINNUS_DEFAULT_GLOBAL_NOTIFICATION_SETTING=3
-)
 class UserNotificationSettingAPITest(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = ActiveUserFactory()
+        init_notification_settings_for_user(cls.user, setting=3, portal_group_setting=0, rocketchat_setting=0)
+
         cls.url = reverse('cosinnus:frontend-api:api-user-notification-setting')
 
         if not GlobalUserNotificationSetting.objects.filter(user=cls.user).exists():
@@ -227,6 +238,7 @@ class ApplyGlobalNotificationSettingsTest(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.user = ActiveUserFactory()
+        init_notification_settings_for_user(cls.user, setting=3, portal_group_setting=0, rocketchat_setting=0)
 
         if not GlobalUserNotificationSetting.objects.filter(user=cls.user).exists():
             raise AssertionError('GlobalUserNotificationSetting does not exist for user.')

--- a/cosinnus/utils/system.py
+++ b/cosinnus/utils/system.py
@@ -14,7 +14,7 @@ TEST_CALENDAR_ARG = '--test-calendar'
 TEST_PRINT_TIME_ARG = '--print-time'
 
 # test apps
-TEST_APPS_BASE = ['cosinnus', 'cosinnus_event', 'cosinnus_todo']
+TEST_APPS_BASE = ['cosinnus', 'cosinnus_event', 'cosinnus_notifications', 'cosinnus_todo']
 TEST_APPS_ROCKET_CHAT = ['cosinnus.tests.test_rocketchat']
 TEST_APPS_BBB = ['cosinnus.tests.test_bbbroom']
 TEST_APPS_ETHERPAD = ['cosinnus_etherpad']

--- a/cosinnus/views/user.py
+++ b/cosinnus/views/user.py
@@ -560,7 +560,7 @@ class WelcomeSettingsView(RequireLoggedInMixin, TemplateView):
             # save global notification setting
             notification_setting = int(request.POST.get('notification_setting', '-1'))
             # the error-messages are ignored here
-            _ = apply_global_notification_settings(request.user, global_setting=notification_setting)
+            apply_global_notification_settings(request.user, global_setting=notification_setting)
 
             # save visibility setting:
             visibility_setting = request.POST.get('visibility_setting', None)


### PR DESCRIPTION
- Replace `override_settings` with explicit DB initialization for notification setting tests, since Django setting overrides do not affect model defaults at object creation time
- Add `init_notification_settings_for_user` helper to set known notification state in test setup
- Add `cosinnus_notifications` to base test apps list
- Remove redundant DB state assertions from RocketChat error handling test
- Remove unused return value assignment from `apply_global_notification_settings` call

https://git.wechange.de/gl/code/redesign/-/issues/437