### PR TITLE
refactor(navigation): deprecate tuple-based v3 menu link settings in favor of dict-based items

### DIFF
--- a/cosinnus/api_frontend/views/content.py
+++ b/cosinnus/api_frontend/views/content.py
@@ -500,11 +500,11 @@ class MainContentView(LanguageMenuItemMixin, APIView):
             self.main_menu_icon = 'fa-map'
 
         # match additional community space links
-        if not self.main_menu_label and settings.COSINNUS_V3_MENU_SPACES_COMMUNITY_ADDITIONAL_LINKS:
-            for __, link_label, link_url, link_icon in settings.COSINNUS_V3_MENU_SPACES_COMMUNITY_ADDITIONAL_LINKS:
-                if url.startswith(str(link_url)):
-                    self.main_menu_label = link_label
-                    self.main_menu_icon = link_icon
+        if not self.main_menu_label and settings.COSINNUS_V3_MENU_SPACES_COMMUNITY_ADDITIONAL_ITEMS:
+            for link_config in settings.COSINNUS_V3_MENU_SPACES_COMMUNITY_ADDITIONAL_ITEMS:
+                if url.startswith(str(link_config['url'])):
+                    self.main_menu_label = link_config['label']
+                    self.main_menu_icon = link_config.get('icon')
 
         # unmatched urls get the "Go to" label
         if not self.main_menu_label:

--- a/cosinnus/api_frontend/views/navigation.py
+++ b/cosinnus/api_frontend/views/navigation.py
@@ -344,12 +344,9 @@ class SpacesView(FilterBlacklistedItemsMixin, MyGroupsClusteredMixin, APIView):
             community_space_items.append(
                 MenuItem(settings.COSINNUS_V3_MENU_SPACES_MAP_LABEL, reverse('cosinnus:map'), 'fa-map', id='Map')
             )
-        if settings.COSINNUS_V3_MENU_SPACES_COMMUNITY_ADDITIONAL_LINKS:
+        if settings.COSINNUS_V3_MENU_SPACES_COMMUNITY_ADDITIONAL_ITEMS:
             community_space_items.extend(
-                [
-                    MenuItem(label, url, icon, id=id)
-                    for id, label, url, icon in settings.COSINNUS_V3_MENU_SPACES_COMMUNITY_ADDITIONAL_LINKS
-                ]
+                [MenuItem(**config) for config in settings.COSINNUS_V3_MENU_SPACES_COMMUNITY_ADDITIONAL_ITEMS]
             )
         if community_space_items:
             community_space_actions = [
@@ -1202,10 +1199,7 @@ class HelpView(APIView):
         }
     )
     def get(self, request):
-        help_items = [
-            MenuItem(label, url, icon, is_external=True, id=id)
-            for id, label, url, icon in settings.COSINNUS_V3_MENU_HELP_LINKS
-        ]
+        help_items = [MenuItem(**{'is_external': True, **config}) for config in settings.COSINNUS_V3_MENU_HELP_ITEMS]
         return Response(help_items)
 
 

--- a/cosinnus/conf.py
+++ b/cosinnus/conf.py
@@ -11,6 +11,19 @@ from django.utils.translation import gettext_lazy as _
 logger = logging.getLogger('cosinnus')
 
 
+def _convert_legacy_v3_menu_links_to_items(legacy_links):
+    """Convert legacy menu link tuples to menu item dictionaries."""
+    return [
+        {
+            'id': id,
+            'label': label,
+            'url': url,
+            'icon': icon,
+        }
+        for id, label, url, icon in legacy_links
+    ]
+
+
 class CosinnusConf(AppConf):
     """Cosinnus settings, any of these values here will be included in the settings,
     with name prefix 'COSINNUS_'.
@@ -1142,14 +1155,42 @@ class CosinnusConf(AppConf):
     # Enable to add links to paired groups of managed tags of the user cosinnus_profile as community links.
     V3_MENU_SPACES_COMMUNITY_LINKS_FROM_MANAGED_TAG_GROUPS = True
 
-    # Additional menu items for the community space in the v3 main navigation.
-    # Format: List of (<id-string>, <label>, <url>, <icon>),
-    # e.g.: [('ExternalLink', 'External Link', 'https://external-link.com', 'fa-group')]
+    # Deprecated tuple-based configuration for additional community space menu items.
+    # Format: List of (<id-string>, <label>, <url>, <icon>) tuples.
     V3_MENU_SPACES_COMMUNITY_ADDITIONAL_LINKS = []
 
-    # List of help items to be included in the v3 main navigation.
-    # Format: (<label>, <url>, <icon>), e.g.: (_('FAQ'), 'https://wechange.de/cms/help/', 'fa-question-circle'),
+    # Additional menu items for the community space in the v3 main navigation.
+    # Format: List of dictionaries containing MenuItem arguments.
+    # If None, V3_MENU_SPACES_COMMUNITY_ADDITIONAL_LINKS is used as a fallback.
+    V3_MENU_SPACES_COMMUNITY_ADDITIONAL_ITEMS = None
+
+    def configure_v3_menu_spaces_community_additional_items(self, value):
+        if value is not None:
+            return value
+        legacy_value = getattr(settings, 'COSINNUS_V3_MENU_SPACES_COMMUNITY_ADDITIONAL_LINKS', [])
+        if legacy_value:
+            logger.warning(
+                'The setting V3_MENU_SPACES_COMMUNITY_ADDITIONAL_LINKS is deprecated. '
+                'Use V3_MENU_SPACES_COMMUNITY_ADDITIONAL_ITEMS instead.'
+            )
+        return _convert_legacy_v3_menu_links_to_items(legacy_value)
+
+    # Deprecated tuple-based configuration for help items in the v3 main navigation.
+    # Format: List of (<id-string>, <label>, <url>, <icon>) tuples.
     V3_MENU_HELP_LINKS = []
+
+    # List of help items to be included in the v3 main navigation.
+    # Format: List of dictionaries containing MenuItem arguments.
+    # If None, V3_MENU_HELP_LINKS is used as a fallback.
+    V3_MENU_HELP_ITEMS = None
+
+    def configure_v3_menu_help_items(self, value):
+        if value is not None:
+            return value
+        legacy_value = getattr(settings, 'COSINNUS_V3_MENU_HELP_LINKS', [])
+        if legacy_value:
+            logger.warning('The setting V3_MENU_HELP_LINKS is deprecated. Use V3_MENU_HELP_ITEMS instead.')
+        return _convert_legacy_v3_menu_links_to_items(legacy_value)
 
     # a class dropin to replace CosinnusNavigationPortalLinksBase as class that modifies or provides additional
     # navbar links returned in various v3 navigation API endpoints

--- a/cosinnus/tests/test_conf.py
+++ b/cosinnus/tests/test_conf.py
@@ -1,0 +1,33 @@
+from django.test import SimpleTestCase, override_settings
+
+from cosinnus.conf import CosinnusConf, _convert_legacy_v3_menu_links_to_items
+
+
+class V3MenuLinkConfigurationTest(SimpleTestCase):
+    def test_convert_legacy_links_to_items(self):
+        result = _convert_legacy_v3_menu_links_to_items([('FAQ', 'FAQ', '/faq/', 'fa-question-circle')])
+
+        self.assertEqual(
+            result,
+            [
+                {
+                    'id': 'FAQ',
+                    'label': 'FAQ',
+                    'url': '/faq/',
+                    'icon': 'fa-question-circle',
+                }
+            ],
+        )
+
+    @override_settings(COSINNUS_V3_MENU_HELP_LINKS=[('FAQ', 'FAQ', '/faq/', 'fa-question-circle')])
+    def test_empty_new_items_override_legacy_links(self):
+        result = CosinnusConf.configure_v3_menu_help_items(None, [])
+
+        self.assertEqual(result, [])
+
+    @override_settings(COSINNUS_V3_MENU_HELP_LINKS=[('FAQ', 'FAQ', '/faq/', 'fa-question-circle')])
+    def test_legacy_links_log_deprecation_warning(self):
+        with self.assertLogs('cosinnus', level='WARNING') as logs:
+            CosinnusConf.configure_v3_menu_help_items(None, None)
+
+        self.assertIn('V3_MENU_HELP_LINKS is deprecated', logs.output[0])

--- a/cosinnus/tests/view_tests/test_navigation_api.py
+++ b/cosinnus/tests/view_tests/test_navigation_api.py
@@ -116,8 +116,14 @@ class SpacesViewTest(APITestCase):
         )
 
     @override_settings(
-        COSINNUS_V3_MENU_SPACES_COMMUNITY_ADDITIONAL_LINKS=[
-            ('ExternalID', 'External', 'https://example.com/', 'fa-group')
+        COSINNUS_V3_MENU_SPACES_COMMUNITY_ADDITIONAL_ITEMS=[
+            {
+                'id': 'ExternalID',
+                'label': 'External',
+                'url': 'https://example.com/',
+                'icon': 'fa-group',
+                'is_external': True,
+            }
         ]
     )
     def test_community_space_additional_links(self):
@@ -125,7 +131,7 @@ class SpacesViewTest(APITestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(
             response.data['community']['items'][1],
-            MenuItem('External', 'https://example.com/', 'fa-group', id='ExternalID'),
+            MenuItem('External', 'https://example.com/', 'fa-group', is_external=True, id='ExternalID'),
         )
 
     @override_settings(COSINNUS_V3_MENU_SPACES_COMMUNITY_LINKS_FROM_MANAGED_TAG_GROUPS=True)
@@ -503,7 +509,16 @@ class HelpViewTest(APITestCase):
         cls.test_user = User.objects.create(**TEST_USER_DATA)
         cls.portal = CosinnusPortal.get_current()
 
-    @override_settings(COSINNUS_V3_MENU_HELP_LINKS=[('faqID', 'FAQ', 'https://example.com/faq/', 'fa-question-circle')])
+    @override_settings(
+        COSINNUS_V3_MENU_HELP_ITEMS=[
+            {
+                'id': 'faqID',
+                'label': 'FAQ',
+                'url': 'https://example.com/faq/',
+                'icon': 'fa-question-circle',
+            }
+        ]
+    )
     def test_help(self):
         response = self.client.get(self.api_url)
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
- Replace `V3_MENU_SPACES_COMMUNITY_ADDITIONAL_LINKS` with `V3_MENU_SPACES_COMMUNITY_ADDITIONAL_ITEMS`
- Replace `V3_MENU_HELP_LINKS` with `V3_MENU_HELP_ITEMS`
- Backwards-compatible: Add `configure_` hooks to auto-convert legacy tuple config and log deprecation warnings
- Update views and tests to use new dict-based config format

https://git.wechange.de/gl/code/portals/nwvv/-/issues/6#note_163124
