### PR TITLE
Remove support email on group BBB premium expiration

### DIFF
--- a/cosinnus/cron.py
+++ b/cosinnus/cron.py
@@ -9,13 +9,12 @@ from typing import List
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import Q
-from django.template.loader import render_to_string
 from django.utils.encoding import force_str
 from django.utils.timezone import now
 from django_cron import CronJobBase, Schedule
 
 from cosinnus.conf import settings
-from cosinnus.core.mail import get_common_mail_context, send_html_mail, send_system_mail_to_support
+from cosinnus.core.mail import send_html_mail
 from cosinnus.core.middleware.cosinnus_middleware import initialize_cosinnus_after_startup
 from cosinnus.models.feedback import CosinnusSentEmailLog
 from cosinnus.models.group import CosinnusBaseGroup, CosinnusPortal
@@ -214,20 +213,6 @@ class SwitchGroupPremiumFeatures(CosinnusCronJobBase):
                         'cosinnus/mail/group_premium_expiration_notification.html',
                         None,
                     )
-                except Exception as e:
-                    logger.error(e, extra={'group': group, 'trace': traceback.format_exc()})
-
-                try:
-                    context = get_common_mail_context(request=None, group=group)
-                    subject = render_to_string('cosinnus/mail/group_premium_expired_notification_subj.txt', context)
-                    body = render_to_string('cosinnus/mail/group_premium_expiration_notification.html', context)
-                    content = '\n'.join((subject, body))
-                    context.update(
-                        {
-                            'content': content,
-                        }
-                    )
-                    send_system_mail_to_support(subject=subject, template=None, data=context, group=group)
                 except Exception as e:
                     logger.error(e, extra={'group': group, 'trace': traceback.format_exc()})
 

--- a/cosinnus/tests/test_group_premium_bbb_states.py
+++ b/cosinnus/tests/test_group_premium_bbb_states.py
@@ -13,8 +13,9 @@ from freezegun import freeze_time
 
 from cosinnus.cron import SendGroupPremiumExpirationWarningEmails, SwitchGroupPremiumFeatures
 from cosinnus.models import MEMBERSHIP_ADMIN
-from cosinnus.models.group import CosinnusBaseGroup, CosinnusGroupMembership
+from cosinnus.models.group import CosinnusBaseGroup, CosinnusGroupMembership, CosinnusPortal
 from cosinnus.models.group_extra import CosinnusProject, CosinnusSociety
+from cosinnus_event.models import Event
 
 User = get_user_model()
 
@@ -240,6 +241,19 @@ class GroupPremiumStateChangeTest(TestDataMixin, TestCase):
             expected_last_warned_for=None,
         )
 
+    def test_expiration_date_today_no_deactivation_triggered(self):
+        self._execute_scenario(
+            '2026-02-01',
+            '2026-02-01',
+            fixture_bbb_active=True,
+            expected_can_have_bbb=True,
+            expected_bbb_active=True,
+            expected_premium_until='2026-02-01',
+            expected_expired_on=None,
+            expected_mails=[self._get_mail_args_warning('2026-02-01', 1)],
+            expected_last_warned_for='2026-02-01',
+        )
+
     def test_active_warning_triggered(self):
         with self.subTest(phase='initial warning mail'):
             self._execute_scenario(
@@ -292,6 +306,46 @@ class GroupPremiumStateChangeTest(TestDataMixin, TestCase):
             expected_mails=[self._get_mail_args_expiration()],
             expected_last_warned_for=None,
         )
+
+    def test_deactivation_resets_event_bbb(self):
+        event = Event.objects.create(
+            group=self.group,
+            creator=self.user,
+            public=True,
+            title='testevent',
+            video_conference_type=Event.BBB_MEETING,
+        )
+
+        self._execute_scenario(
+            '2026-02-01',
+            '2026-01-31',
+            fixture_bbb_active=True,
+            expected_can_have_bbb=False,
+            expected_bbb_active=False,
+            expected_premium_until=None,
+            expected_expired_on='2026-02-01',
+            expected_mails=[self._get_mail_args_expiration()],
+            expected_last_warned_for=None,
+        )
+
+        event.refresh_from_db()
+        self.assertEqual(event.video_conference_type, Event.NO_VIDEO_CONFERENCE)
+
+    def test_deactivation_falls_back_to_fairmeeting(self):
+        portal = CosinnusPortal.get_current()
+        portal.video_conference_server = 'https://video.example.com/'
+
+        with freeze_time('2026-02-01'), patch.object(CosinnusPortal, 'get_current', return_value=portal), patch(
+            'cosinnus.cron.email_group_admins'
+        ):
+            self.group.enable_user_premium_choices_until = '2026-01-31'
+            self.group.video_conference_type = CosinnusBaseGroup.BBB_MEETING
+            self.group.save()
+
+            SwitchGroupPremiumFeatures().do()
+            self.group.refresh_from_db()
+
+            self.assertTrue(self.group.video_conference_type == CosinnusBaseGroup.FAIRMEETING)
 
     def test_expired_no_action_needed(self):
         self._execute_scenario(

--- a/cosinnus/tests/test_group_premium_bbb_states.py
+++ b/cosinnus/tests/test_group_premium_bbb_states.py
@@ -148,9 +148,7 @@ class GroupPremiumStateChangeTest(TestDataMixin, TestCase):
         expected_mails: List[SendHtmlMailCallArgs],
     ):
         expected_mail_count = len(expected_mails)
-        with freeze_time(current_date), patch('cosinnus.core.mail.send_html_mail') as mock_send_group_admins, patch(
-            'cosinnus.cron.send_system_mail_to_support'
-        ) as mock_send_system_mail:
+        with freeze_time(current_date), patch('cosinnus.core.mail.send_html_mail') as mock_send_group_admins:
             # set state
             # TODO test this for project also
             self.group.enable_user_premium_choices_until = premium_until
@@ -207,10 +205,6 @@ class GroupPremiumStateChangeTest(TestDataMixin, TestCase):
                 self.assertEqual(
                     expected_last_warned_for, self.group.settings.get('last_warned_for_premium_choices_until')
                 )
-
-            should_be_expired = fixture_bbb_active and not expected_bbb_active
-            with self.subTest('send notification to portal support email', should_be_expired=should_be_expired):
-                self.assertEqual(should_be_expired, mock_send_system_mail.called)
 
     def _get_mail_args_expiration(self) -> SendHtmlMailCallArgs:
         return SendHtmlMailCallArgs(


### PR DESCRIPTION
- refactor(cron): Remove `send_system_mail_to_support` call and related template rendering when group premium expires, as the notification is no longer needed
- test(cron): Remove assertion for support email sending from existing test helper

extra tests, not related:
- test(cron): Add test for expiration date matching current date (no deactivation triggered)
- test(cron): Add test verifying event BBB type resets to `NO_VIDEO_CONFERENCE` on premium expiration
- test(cron): Add test verifying group falls back to `FAIRMEETING` when portal has a video conference server configured


https://git.wechange.de/gl/code/cooperation/-/issues/677